### PR TITLE
Fix theme to AppCompat

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.TZD" parent="android:Theme.Material.Light.NoActionBar" />
+    <!-- Використовуємо тему з бібліотеки AppCompat, щоб уникнути помилки "You need to use a Theme.AppCompat theme" -->
+    <style name="Theme.TZD" parent="Theme.AppCompat.Light.NoActionBar" />
 </resources>


### PR DESCRIPTION
## Summary
- use AppCompat-based theme

## Testing
- `./gradlew test` *(fails: HTTP 403 when downloading gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_6887e9c4ac388320a6b4313cdc165c77