### PR TITLE
Add settings screen with FTP check

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.TZD">
+        <activity android:name=".SettingsActivity" />
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/src/main/java/ua/company/tzd/MainActivity.kt
+++ b/app/src/main/java/ua/company/tzd/MainActivity.kt
@@ -1,5 +1,6 @@
 package ua.company.tzd
 
+import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
 // AppCompatActivity міститься у бібліотеці appcompat, яка додає підтримку
@@ -30,11 +31,10 @@ class MainActivity : AppCompatActivity() {
             // startActivity(Intent(this, SentActivity::class.java))
         }
 
-        // Кнопка "Налаштування" відкриватиме екран з налаштуваннями програми
-        // Обробник натискання поки що містить лише TODO
+        // Кнопка "Налаштування" відкриває екран SettingsActivity
         findViewById<Button>(R.id.btnSettings).setOnClickListener {
-            // TODO: реалізувати перехід на SettingsActivity
-            // startActivity(Intent(this, SettingsActivity::class.java))
+            // Запускаємо активність налаштувань через Intent
+            startActivity(Intent(this, SettingsActivity::class.java))
         }
     }
 }

--- a/app/src/main/java/ua/company/tzd/SettingsActivity.kt
+++ b/app/src/main/java/ua/company/tzd/SettingsActivity.kt
@@ -1,0 +1,110 @@
+package ua.company.tzd
+
+import android.content.SharedPreferences
+import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.net.InetSocketAddress
+import java.net.Socket
+
+/**
+ * Екран налаштувань програми.
+ * Дає змогу вказати параметри розбору штрихкоду
+ * та реквізити підключення до FTP-сервера.
+ */
+class SettingsActivity : AppCompatActivity() {
+
+    /** SharedPreferences, де зберігаємо налаштування */
+    private lateinit var prefs: SharedPreferences
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        // Підключаємо розмітку activity_settings.xml
+        setContentView(R.layout.activity_settings)
+
+        // Отримуємо сховище налаштувань під ім'ям "tzd_settings"
+        prefs = getSharedPreferences("tzd_settings", MODE_PRIVATE)
+
+        // Поля для параметрів штрихкоду
+        val codeStart = findViewById<EditText>(R.id.inputCodeStart)
+        val codeLength = findViewById<EditText>(R.id.inputCodeLength)
+        val weightKgStart = findViewById<EditText>(R.id.inputWeightKgStart)
+        val weightKgLength = findViewById<EditText>(R.id.inputWeightKgLength)
+        val weightGrStart = findViewById<EditText>(R.id.inputWeightGrStart)
+        val weightGrLength = findViewById<EditText>(R.id.inputWeightGrLength)
+        val countStart = findViewById<EditText>(R.id.inputCountStart)
+        val countLength = findViewById<EditText>(R.id.inputCountLength)
+        val delayMs = findViewById<EditText>(R.id.inputDelay)
+
+        // Поля для налаштування FTP
+        val ftpHost = findViewById<EditText>(R.id.inputFtpHost)
+        val ftpPort = findViewById<EditText>(R.id.inputFtpPort)
+        val ftpUser = findViewById<EditText>(R.id.inputFtpUser)
+        val ftpPass = findViewById<EditText>(R.id.inputFtpPass)
+
+        val btnSave = findViewById<Button>(R.id.btnSaveSettings)
+        val btnTestFtp = findViewById<Button>(R.id.btnTestFtp)
+
+        // Завантажуємо збережені значення або підставляємо типові
+        codeStart.setText(prefs.getInt("codeStart", 0).toString())
+        codeLength.setText(prefs.getInt("codeLength", 3).toString())
+        weightKgStart.setText(prefs.getInt("weightKgStart", 3).toString())
+        weightKgLength.setText(prefs.getInt("weightKgLength", 3).toString())
+        weightGrStart.setText(prefs.getInt("weightGrStart", 6).toString())
+        weightGrLength.setText(prefs.getInt("weightGrLength", 1).toString())
+        countStart.setText(prefs.getInt("countStart", 7).toString())
+        countLength.setText(prefs.getInt("countLength", 2).toString())
+        delayMs.setText(prefs.getInt("delayMs", 2000).toString())
+
+        ftpHost.setText(prefs.getString("ftpHost", ""))
+        ftpPort.setText(prefs.getInt("ftpPort", 21).toString())
+        ftpUser.setText(prefs.getString("ftpUser", ""))
+        ftpPass.setText(prefs.getString("ftpPass", ""))
+
+        // Зберігаємо введені дані у SharedPreferences
+        btnSave.setOnClickListener {
+            prefs.edit().apply {
+                putInt("codeStart", codeStart.text.toString().toInt())
+                putInt("codeLength", codeLength.text.toString().toInt())
+                putInt("weightKgStart", weightKgStart.text.toString().toInt())
+                putInt("weightKgLength", weightKgLength.text.toString().toInt())
+                putInt("weightGrStart", weightGrStart.text.toString().toInt())
+                putInt("weightGrLength", weightGrLength.text.toString().toInt())
+                putInt("countStart", countStart.text.toString().toInt())
+                putInt("countLength", countLength.text.toString().toInt())
+                putInt("delayMs", delayMs.text.toString().toInt())
+                putString("ftpHost", ftpHost.text.toString())
+                putInt("ftpPort", ftpPort.text.toString().toInt())
+                putString("ftpUser", ftpUser.text.toString())
+                putString("ftpPass", ftpPass.text.toString())
+                apply()
+            }
+            Toast.makeText(this, "Налаштування збережено", Toast.LENGTH_SHORT).show()
+        }
+
+        // Перевіряємо доступність FTP-серверу
+        btnTestFtp.setOnClickListener {
+            val host = ftpHost.text.toString()
+            val port = ftpPort.text.toString().toInt()
+            CoroutineScope(Dispatchers.IO).launch {
+                try {
+                    Socket().use { socket ->
+                        socket.connect(InetSocketAddress(host, port), 3000)
+                        runOnUiThread {
+                            Toast.makeText(this@SettingsActivity, "FTP-доступ успішний", Toast.LENGTH_SHORT).show()
+                        }
+                    }
+                } catch (e: Exception) {
+                    runOnUiThread {
+                        Toast.makeText(this@SettingsActivity, "Помилка з'єднання з FTP", Toast.LENGTH_SHORT).show()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1,0 +1,58 @@
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <!-- Штрихкод -->
+        <TextView android:text="Код товару:" android:layout_width="wrap_content" android:layout_height="wrap_content"/>
+        <EditText android:id="@+id/inputCodeStart" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="Початок"/>
+        <EditText android:id="@+id/inputCodeLength" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="Довжина"/>
+
+        <TextView android:text="Вага (кг):" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="16dp"/>
+        <EditText android:id="@+id/inputWeightKgStart" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="Початок"/>
+        <EditText android:id="@+id/inputWeightKgLength" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="Довжина"/>
+
+        <TextView android:text="Вага (г):" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="16dp"/>
+        <EditText android:id="@+id/inputWeightGrStart" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="Початок"/>
+        <EditText android:id="@+id/inputWeightGrLength" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="Довжина"/>
+
+        <TextView android:text="Кількість упаковок:" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="16dp"/>
+        <EditText android:id="@+id/inputCountStart" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="Початок"/>
+        <EditText android:id="@+id/inputCountLength" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="Довжина"/>
+
+        <TextView android:text="Затримка після сканування (мс):" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="16dp"/>
+        <EditText android:id="@+id/inputDelay" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="2000"/>
+
+        <!-- FTP -->
+        <TextView android:text="FTP сервер:" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="24dp"/>
+        <EditText android:id="@+id/inputFtpHost" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="ftp.example.com"/>
+
+        <TextView android:text="FTP порт:" android:layout_width="wrap_content" android:layout_height="wrap_content"/>
+        <EditText android:id="@+id/inputFtpPort" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="21"/>
+
+        <TextView android:text="FTP логін:" android:layout_width="wrap_content" android:layout_height="wrap_content"/>
+        <EditText android:id="@+id/inputFtpUser" android:layout_width="match_parent" android:layout_height="wrap_content"/>
+
+        <TextView android:text="FTP пароль:" android:layout_width="wrap_content" android:layout_height="wrap_content"/>
+        <EditText android:id="@+id/inputFtpPass" android:layout_width="match_parent" android:layout_height="wrap_content" android:inputType="textPassword"/>
+
+        <Button
+            android:id="@+id/btnTestFtp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Перевірити FTP"
+            android:layout_marginTop="16dp" />
+
+        <Button
+            android:id="@+id/btnSaveSettings"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Зберегти"
+            android:layout_marginTop="16dp" />
+    </LinearLayout>
+</ScrollView>


### PR DESCRIPTION
## Summary
- add `SettingsActivity` for managing barcode and FTP settings
- wire up the new activity from `MainActivity`
- register `SettingsActivity` in `AndroidManifest`
- create XML layout for settings screen

## Testing
- `./gradlew test` *(fails: Unable to download Gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6887ee1dbc9c83209435bf54cff344dd