### PR TITLE
Fix FTP error reporting and add internet permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <!-- Додаємо дозвіл на доступ до інтернету -->
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -10,6 +13,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:usesCleartextTraffic="true"
         android:theme="@style/Theme.TZD">
         <activity android:name=".SettingsActivity" />
         <activity

--- a/app/src/main/java/ua/company/tzd/SettingsActivity.kt
+++ b/app/src/main/java/ua/company/tzd/SettingsActivity.kt
@@ -116,9 +116,16 @@ class SettingsActivity : AppCompatActivity() {
                     ftpClient.logout()
                     ftpClient.disconnect()
                 } catch (e: Exception) {
+                    // Виводимо текст помилки у Logcat, щоб розробник міг побачити деталі
+                    e.printStackTrace()
                     // У разі помилки також показуємо повідомлення на головному потоці
+                    // з точним типом винятку та його повідомленням
                     runOnUiThread {
-                        Toast.makeText(this@SettingsActivity, "❌ Помилка з'єднання: ${'$'}{e.message}", Toast.LENGTH_LONG).show()
+                        Toast.makeText(
+                            this@SettingsActivity,
+                            "❌ Помилка: " + e.javaClass.name + " - " + e.message,
+                            Toast.LENGTH_LONG
+                        ).show()
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- allow cleartext and network access in manifest
- show detailed FTP error information

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6888ab2960508320817a4b1fa6f6647d