### PR TITLE
Add product list activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,8 @@
         android:usesCleartextTraffic="true"
         android:theme="@style/Theme.TZD">
         <activity android:name=".SettingsActivity" />
+        <!-- Активність зі списком товарів -->
+        <activity android:name=".ProductListActivity" />
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/src/main/java/ua/company/tzd/MainActivity.kt
+++ b/app/src/main/java/ua/company/tzd/MainActivity.kt
@@ -36,5 +36,12 @@ class MainActivity : AppCompatActivity() {
             // Запускаємо активність налаштувань через Intent
             startActivity(Intent(this, SettingsActivity::class.java))
         }
+
+        // Кнопка "Товари" відкриває новий екран зі списком товарів
+        findViewById<Button>(R.id.btnProducts).setOnClickListener {
+            // Створюємо Intent для запуску ProductListActivity
+            val intent = Intent(this, ProductListActivity::class.java)
+            startActivity(intent)
+        }
     }
 }

--- a/app/src/main/java/ua/company/tzd/ProductListActivity.kt
+++ b/app/src/main/java/ua/company/tzd/ProductListActivity.kt
@@ -1,0 +1,155 @@
+package ua.company.tzd
+
+import android.os.Bundle
+import android.widget.Button
+import android.widget.TableLayout
+import android.widget.TableRow
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import org.apache.commons.net.ftp.FTPClient
+import org.xmlpull.v1.XmlPullParser
+import org.xmlpull.v1.XmlPullParserFactory
+import java.io.InputStream
+import java.net.InetAddress
+
+/**
+ * Екран для відображення списку товарів, отриманого з FTP-сервера.
+ *
+ * Додаємо багато детальних коментарів, щоб будь-хто міг зрозуміти,
+ * що саме відбувається у коді.
+ */
+class ProductListActivity : AppCompatActivity() {
+
+    /** Таблиця у якій будемо показувати товари */
+    private lateinit var tableLayout: TableLayout
+
+    /** Клієнт для роботи з FTP */
+    private val ftpClient = FTPClient()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        // Підключаємо розмітку activity_product_list.xml
+        setContentView(R.layout.activity_product_list)
+
+        // Знаходимо таблицю у розмітці за її ID
+        tableLayout = findViewById(R.id.tableLayoutProducts)
+
+        // Кнопка "Назад" просто закриває поточну активність
+        findViewById<Button>(R.id.btnBack).setOnClickListener {
+            finish()
+        }
+
+        // Кнопка "Оновити" завантажує файл з FTP і відображає результат
+        findViewById<Button>(R.id.btnRefresh).setOnClickListener {
+            downloadAndShowProducts()
+        }
+
+        // Відразу при відкритті екрану пробуємо завантажити дані
+        downloadAndShowProducts()
+    }
+
+    /**
+     * Завантажити файл з FTP-сервера та заповнити таблицю отриманими даними.
+     *
+     * Операція мережі виконується у окремому потоці, адже Android не дозволяє
+     * робити це на головному UI-потоці.
+     */
+    private fun downloadAndShowProducts() {
+        // Запускаємо новий потік для завантаження файлу
+        Thread {
+            try {
+                // Отримуємо налаштування FTP із SharedPreferences,
+                // які ми зберігали у SettingsActivity
+                val prefs = getSharedPreferences("tzd_settings", MODE_PRIVATE)
+                val host = prefs.getString("ftpHost", "") ?: ""
+                val port = prefs.getInt("ftpPort", 21)
+                val user = prefs.getString("ftpUser", "") ?: ""
+                val pass = prefs.getString("ftpPass", "") ?: ""
+
+                // Підключаємося до FTP-сервера за отриманими реквізитами
+                ftpClient.connect(InetAddress.getByName(host), port)
+
+                // Логін з вказаним логіном та паролем
+                if (ftpClient.login(user, pass)) {
+                    // Переходимо в пасивний режим та обираємо двійковий тип файлів
+                    ftpClient.enterLocalPassiveMode()
+                    ftpClient.setFileType(FTPClient.BINARY_FILE_TYPE)
+
+                    // Витягаємо файл products.xml з кореня FTP
+                    val inputStream: InputStream = ftpClient.retrieveFileStream("/products.xml")
+
+                    // Створюємо XML парсер для читання файлу
+                    val factory = XmlPullParserFactory.newInstance()
+                    val parser = factory.newPullParser()
+                    parser.setInput(inputStream, null)
+
+                    // Список пар "код" - "назва" для кожного товару
+                    val products = mutableListOf<Pair<String, String>>()
+
+                    var event = parser.eventType
+                    var code = ""
+                    var name = ""
+
+                    // Читаємо XML доки не дійдемо до його кінця
+                    while (event != XmlPullParser.END_DOCUMENT) {
+                        val tag = parser.name
+                        when (event) {
+                            XmlPullParser.START_TAG -> {
+                                when (tag) {
+                                    // Початок елемента <product>
+                                    "product" -> {
+                                        code = ""
+                                        name = ""
+                                    }
+                                    // Елемент <code>
+                                    "code" -> code = parser.nextText()
+                                    // Елемент <name>
+                                    "name" -> name = parser.nextText()
+                                }
+                            }
+                            XmlPullParser.END_TAG -> {
+                                // Кінець елемента <product> - додаємо товар у список
+                                if (tag == "product") {
+                                    products.add(Pair(code, name))
+                                }
+                            }
+                        }
+                        event = parser.next()
+                    }
+
+                    // Закриваємо потік та розриваємо з'єднання з сервером
+                    inputStream.close()
+                    ftpClient.logout()
+                    ftpClient.disconnect()
+
+                    // Повертаємося на головний потік, щоб оновити інтерфейс
+                    runOnUiThread {
+                        // Спочатку очищаємо таблицю від попередніх рядків
+                        tableLayout.removeAllViews()
+                        // Для кожного товару створюємо рядок і додаємо у таблицю
+                        for ((c, n) in products) {
+                            val row = TableRow(this)
+
+                            val tvCode = TextView(this)
+                            val tvName = TextView(this)
+
+                            tvCode.text = c
+                            tvName.text = n
+
+                            // Невеликий відступ для кращого вигляду
+                            tvCode.setPadding(16, 16, 16, 16)
+                            tvName.setPadding(16, 16, 16, 16)
+
+                            row.addView(tvCode)
+                            row.addView(tvName)
+                            tableLayout.addView(row)
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                // У разі помилки просто виводимо стек трасації у лог
+                e.printStackTrace()
+            }
+        }.start()
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -30,4 +30,12 @@
         android:layout_height="wrap_content"
         android:text="Налаштування"
         android:layout_marginTop="16dp" />
+
+    <!-- Кнопка для перегляду списку товарів -->
+    <Button
+        android:id="@+id/btnProducts"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Товари"
+        android:layout_marginTop="16dp" />
 </LinearLayout>

--- a/app/src/main/res/layout/activity_product_list.xml
+++ b/app/src/main/res/layout/activity_product_list.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+        <TableLayout
+            android:id="@+id/tableLayoutProducts"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:stretchColumns="*"/>
+    </ScrollView>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:weightSum="2"
+        android:padding="8dp">
+
+        <Button
+            android:id="@+id/btnRefresh"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="Оновити"/>
+
+        <Button
+            android:id="@+id/btnBack"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="Назад"/>
+    </LinearLayout>
+</LinearLayout>


### PR DESCRIPTION
## Summary
- add product list button on the main screen
- implement new `ProductListActivity` to download and show XML data from FTP
- include a layout for the product list screen
- register the new activity in the manifest

## Testing
- `./gradlew test` *(fails: Unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688b225a73148320ad43738978a71d46