### PR TITLE
Add font scale and FTP import path settings

### DIFF
--- a/app/src/main/java/ua/company/tzd/MainActivity.kt
+++ b/app/src/main/java/ua/company/tzd/MainActivity.kt
@@ -17,28 +17,43 @@ class MainActivity : AppCompatActivity() {
         // Підключаємо файл розмітки activity_main.xml як вигляд для цієї активності
         setContentView(R.layout.activity_main)
 
+        // Зчитуємо збережений масштаб шрифтів
+        val prefs = getSharedPreferences("tzd_settings", MODE_PRIVATE)
+        val scale = prefs.getInt("ui_font_scale", 100) / 100.0f
+
         // За допомогою findViewById отримуємо кнопку з розмітки за її ID
         // і додаємо обробник натискання
-        findViewById<Button>(R.id.btnOrders).setOnClickListener {
+        val btnOrders = findViewById<Button>(R.id.btnOrders)
+        val btnSent = findViewById<Button>(R.id.btnSent)
+        val btnSettings = findViewById<Button>(R.id.btnSettings)
+        val btnProducts = findViewById<Button>(R.id.btnProducts)
+
+        // Застосовуємо масштаб до тексту кнопок
+        btnOrders.textSize = btnOrders.textSize * scale
+        btnSent.textSize = btnSent.textSize * scale
+        btnSettings.textSize = btnSettings.textSize * scale
+        btnProducts.textSize = btnProducts.textSize * scale
+
+        btnOrders.setOnClickListener {
             // TODO: коли буде створено екран замовлень, тут відкрити його через Intent
             // startActivity(Intent(this, OrdersActivity::class.java))
         }
 
         // Аналогічно отримуємо кнопку відправлених документів
         // та навішуємо на неї обробник натискання
-        findViewById<Button>(R.id.btnSent).setOnClickListener {
+        btnSent.setOnClickListener {
             // TODO: реалізувати відкриття відповідної активності
             // startActivity(Intent(this, SentActivity::class.java))
         }
 
         // Кнопка "Налаштування" відкриває екран SettingsActivity
-        findViewById<Button>(R.id.btnSettings).setOnClickListener {
+        btnSettings.setOnClickListener {
             // Запускаємо активність налаштувань через Intent
             startActivity(Intent(this, SettingsActivity::class.java))
         }
 
         // Кнопка "Товари" відкриває новий екран зі списком товарів
-        findViewById<Button>(R.id.btnProducts).setOnClickListener {
+        btnProducts.setOnClickListener {
             // Створюємо Intent для запуску ProductListActivity
             val intent = Intent(this, ProductListActivity::class.java)
             startActivity(intent)

--- a/app/src/main/java/ua/company/tzd/SettingsActivity.kt
+++ b/app/src/main/java/ua/company/tzd/SettingsActivity.kt
@@ -25,16 +25,18 @@ class SettingsActivity : AppCompatActivity() {
 
         // Отримуємо сховище налаштувань під ім'ям "tzd_settings"
         prefs = getSharedPreferences("tzd_settings", MODE_PRIVATE)
+        val uiScale = prefs.getInt("ui_font_scale", 100) / 100.0f
 
-        // Поля для параметрів штрихкоду
-        val codeStart = findViewById<EditText>(R.id.inputCodeStart)
-        val codeLength = findViewById<EditText>(R.id.inputCodeLength)
-        val weightKgStart = findViewById<EditText>(R.id.inputWeightKgStart)
-        val weightKgLength = findViewById<EditText>(R.id.inputWeightKgLength)
-        val weightGrStart = findViewById<EditText>(R.id.inputWeightGrStart)
-        val weightGrLength = findViewById<EditText>(R.id.inputWeightGrLength)
-        val countStart = findViewById<EditText>(R.id.inputCountStart)
-        val countLength = findViewById<EditText>(R.id.inputCountLength)
+        // Поля для параметрів штрихкоду, які тепер розміщені у таблиці GridLayout
+        val productStart = findViewById<EditText>(R.id.inputProductStart)
+        val productLength = findViewById<EditText>(R.id.inputProductLength)
+        val qtyStart = findViewById<EditText>(R.id.inputQtyStart)
+        val qtyLength = findViewById<EditText>(R.id.inputQtyLength)
+        val kgStart = findViewById<EditText>(R.id.inputKgStart)
+        val kgLength = findViewById<EditText>(R.id.inputKgLength)
+        val grStart = findViewById<EditText>(R.id.inputGrStart)
+        val grLength = findViewById<EditText>(R.id.inputGrLength)
+        // Затримка після сканування лишилась окремим полем
         val delayMs = findViewById<EditText>(R.id.inputDelay)
 
         // Поля для налаштування FTP
@@ -48,39 +50,51 @@ class SettingsActivity : AppCompatActivity() {
 
         val btnSave = findViewById<Button>(R.id.btnSaveSettings)
         val btnTestFtp = findViewById<Button>(R.id.btnTestFtp)
+        // Підлаштовуємо розмір шрифту кнопок згідно з масштабом
+        btnSave.textSize = btnSave.textSize * uiScale
+        btnTestFtp.textSize = btnTestFtp.textSize * uiScale
 
         // Завантажуємо збережені значення або підставляємо типові
-        codeStart.setText(prefs.getInt("codeStart", 0).toString())
-        codeLength.setText(prefs.getInt("codeLength", 3).toString())
-        weightKgStart.setText(prefs.getInt("weightKgStart", 3).toString())
-        weightKgLength.setText(prefs.getInt("weightKgLength", 3).toString())
-        weightGrStart.setText(prefs.getInt("weightGrStart", 6).toString())
-        weightGrLength.setText(prefs.getInt("weightGrLength", 1).toString())
-        countStart.setText(prefs.getInt("countStart", 7).toString())
-        countLength.setText(prefs.getInt("countLength", 2).toString())
+        productStart.setText(prefs.getInt("codeStart", 0).toString())
+        productLength.setText(prefs.getInt("codeLength", 3).toString())
+        qtyStart.setText(prefs.getInt("countStart", 7).toString())
+        qtyLength.setText(prefs.getInt("countLength", 2).toString())
+        kgStart.setText(prefs.getInt("weightKgStart", 3).toString())
+        kgLength.setText(prefs.getInt("weightKgLength", 3).toString())
+        grStart.setText(prefs.getInt("weightGrStart", 6).toString())
+        grLength.setText(prefs.getInt("weightGrLength", 1).toString())
         delayMs.setText(prefs.getInt("delayMs", 2000).toString())
 
         ftpHost.setText(prefs.getString("ftpHost", ""))
         ftpPort.setText(prefs.getInt("ftpPort", 21).toString())
         ftpUser.setText(prefs.getString("ftpUser", ""))
         ftpPass.setText(prefs.getString("ftpPass", ""))
+        ftpImportDir.setText(prefs.getString("ftpImportDir", ""))
+        ftpExportDir.setText(prefs.getString("ftpExportDir", ""))
+
+        val inputFontScale = findViewById<EditText>(R.id.inputFontScale)
+        inputFontScale.setText(prefs.getInt("ui_font_scale", 100).toString())
 
         // Зберігаємо введені дані у SharedPreferences
         btnSave.setOnClickListener {
             prefs.edit().apply {
-                putInt("codeStart", codeStart.text.toString().toInt())
-                putInt("codeLength", codeLength.text.toString().toInt())
-                putInt("weightKgStart", weightKgStart.text.toString().toInt())
-                putInt("weightKgLength", weightKgLength.text.toString().toInt())
-                putInt("weightGrStart", weightGrStart.text.toString().toInt())
-                putInt("weightGrLength", weightGrLength.text.toString().toInt())
-                putInt("countStart", countStart.text.toString().toInt())
-                putInt("countLength", countLength.text.toString().toInt())
+                // Зберігаємо параметри розбору штрихкоду
+                putInt("codeStart", productStart.text.toString().toInt())
+                putInt("codeLength", productLength.text.toString().toInt())
+                putInt("countStart", qtyStart.text.toString().toInt())
+                putInt("countLength", qtyLength.text.toString().toInt())
+                putInt("weightKgStart", kgStart.text.toString().toInt())
+                putInt("weightKgLength", kgLength.text.toString().toInt())
+                putInt("weightGrStart", grStart.text.toString().toInt())
+                putInt("weightGrLength", grLength.text.toString().toInt())
                 putInt("delayMs", delayMs.text.toString().toInt())
                 putString("ftpHost", ftpHost.text.toString())
                 putInt("ftpPort", ftpPort.text.toString().toInt())
                 putString("ftpUser", ftpUser.text.toString())
                 putString("ftpPass", ftpPass.text.toString())
+                putString("ftpImportDir", ftpImportDir.text.toString())
+                putString("ftpExportDir", ftpExportDir.text.toString())
+                putInt("ui_font_scale", inputFontScale.text.toString().toIntOrNull() ?: 100)
                 apply()
             }
             Toast.makeText(this, "Налаштування збережено", Toast.LENGTH_SHORT).show()

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -8,65 +9,147 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <!-- Штрихкод -->
-        <TextView android:text="Код товару:" android:layout_width="wrap_content" android:layout_height="wrap_content"/>
-        <EditText android:id="@+id/inputCodeStart" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="Початок"/>
-        <EditText android:id="@+id/inputCodeLength" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="Довжина"/>
+        <!-- Заголовок секції налаштувань сканера -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Сканер"
+            android:textStyle="bold"
+            android:paddingTop="16dp"/>
 
-        <TextView android:text="Вага (кг):" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="16dp"/>
-        <EditText android:id="@+id/inputWeightKgStart" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="Початок"/>
-        <EditText android:id="@+id/inputWeightKgLength" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="Довжина"/>
+        <!-- Таблиця параметрів сканера -->
+        <GridLayout
+            android:id="@+id/scannerSettingsGrid"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:columnCount="3"
+            android:padding="8dp">
 
-        <TextView android:text="Вага (г):" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="16dp"/>
-        <EditText android:id="@+id/inputWeightGrStart" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="Початок"/>
-        <EditText android:id="@+id/inputWeightGrLength" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="Довжина"/>
+            <TextView android:text="Параметр"/>
+            <TextView android:text="Початок"/>
+            <TextView android:text="Довжина"/>
 
-        <TextView android:text="Кількість упаковок:" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="16dp"/>
-        <EditText android:id="@+id/inputCountStart" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="Початок"/>
-        <EditText android:id="@+id/inputCountLength" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="Довжина"/>
+            <TextView android:text="Код товару"/>
+            <EditText android:id="@+id/inputProductStart"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"/>
+            <EditText android:id="@+id/inputProductLength"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"/>
 
-        <TextView android:text="Затримка після сканування (мс):" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="16dp"/>
-        <EditText android:id="@+id/inputDelay" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="2000"/>
+            <TextView android:text="К-сть упаковок"/>
+            <EditText android:id="@+id/inputQtyStart"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"/>
+            <EditText android:id="@+id/inputQtyLength"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"/>
 
-        <!-- FTP -->
-        <TextView android:text="FTP сервер:" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="24dp"/>
-        <EditText android:id="@+id/inputFtpHost" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="ftp.example.com"/>
+            <TextView android:text="Вага (кг)"/>
+            <EditText android:id="@+id/inputKgStart"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"/>
+            <EditText android:id="@+id/inputKgLength"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"/>
 
-        <TextView android:text="FTP порт:" android:layout_width="wrap_content" android:layout_height="wrap_content"/>
-        <EditText android:id="@+id/inputFtpPort" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="21"/>
+            <TextView android:text="Вага (г)"/>
+            <EditText android:id="@+id/inputGrStart"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"/>
+            <EditText android:id="@+id/inputGrLength"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"/>
+        </GridLayout>
 
-        <TextView android:text="FTP логін:" android:layout_width="wrap_content" android:layout_height="wrap_content"/>
-        <EditText android:id="@+id/inputFtpUser" android:layout_width="match_parent" android:layout_height="wrap_content"/>
+        <!-- Поле затримки після сканування залишається окремо -->
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Затримка після сканування (мс):"
+            android:layout_marginTop="16dp"/>
+        <EditText
+            android:id="@+id/inputDelay"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="2000"/>
 
-        <TextView android:text="FTP пароль:" android:layout_width="wrap_content" android:layout_height="wrap_content"/>
-        <EditText android:id="@+id/inputFtpPass" android:layout_width="match_parent" android:layout_height="wrap_content" android:inputType="textPassword"/>
+        <!-- Заголовок секції FTP -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="FTP"
+            android:textStyle="bold"
+            android:paddingTop="16dp"/>
 
-        <!-- Каталог для імпорту файлів на сервері -->
+        <TextView android:text="FTP сервер:"/>
+        <EditText
+            android:id="@+id/inputFtpHost"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="ftp.example.com"/>
+
+        <TextView android:text="FTP порт:"/>
+        <EditText
+            android:id="@+id/inputFtpPort"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="21"/>
+
+        <TextView android:text="FTP логін:"/>
+        <EditText
+            android:id="@+id/inputFtpUser"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"/>
+
+        <TextView android:text="FTP пароль:"/>
+        <EditText
+            android:id="@+id/inputFtpPass"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="textPassword"/>
+
+        <!-- Каталоги на FTP -->
         <EditText
             android:id="@+id/inputFtpImportDir"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Каталог імпорту" />
+            android:hint="Каталог імпорту"/>
 
-        <!-- Каталог для експорту файлів на сервері -->
         <EditText
             android:id="@+id/inputFtpExportDir"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Каталог експорту" />
+            android:hint="Каталог експорту"/>
 
+        <!-- Заголовок секції інтерфейсу -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Інтерфейс"
+            android:textStyle="bold"
+            android:paddingTop="16dp"/>
+
+        <!-- Масштаб шрифтів -->
+        <EditText
+            android:id="@+id/inputFontScale"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Зум (%)"/>
+
+        <!-- Кнопки збереження та перевірки -->
         <Button
             android:id="@+id/btnTestFtp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Перевірити FTP"
-            android:layout_marginTop="16dp" />
+            android:layout_marginTop="16dp"/>
 
         <Button
             android:id="@+id/btnSaveSettings"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Зберегти"
-            android:layout_marginTop="16dp" />
+            android:layout_marginTop="16dp"/>
     </LinearLayout>
 </ScrollView>


### PR DESCRIPTION
## Summary
- fetch product file from custom FTP directory
- allow long product names to wrap
- scale text sizes based on user setting
- organize Settings screen with sections and scanner grid
- add font zoom preference and apply on UI buttons

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b2e0c77dc83208a6259a1a6629f90