### PR TITLE
Add import dir and UI font scaling

### DIFF
--- a/app/src/main/java/ua/company/tzd/MainActivity.kt
+++ b/app/src/main/java/ua/company/tzd/MainActivity.kt
@@ -17,28 +17,43 @@ class MainActivity : AppCompatActivity() {
         // Підключаємо файл розмітки activity_main.xml як вигляд для цієї активності
         setContentView(R.layout.activity_main)
 
-        // За допомогою findViewById отримуємо кнопку з розмітки за її ID
-        // і додаємо обробник натискання
-        findViewById<Button>(R.id.btnOrders).setOnClickListener {
+        // Зчитуємо масштаб шрифту з налаштувань користувача
+        val prefs = getSharedPreferences("tzd_settings", MODE_PRIVATE)
+        val scale = prefs.getInt("ui_font_scale", 100) / 100.0f
+
+        // Отримуємо кнопки з розмітки
+        val btnOrders = findViewById<Button>(R.id.btnOrders)
+        val btnSent = findViewById<Button>(R.id.btnSent)
+        val btnSettings = findViewById<Button>(R.id.btnSettings)
+        val btnProducts = findViewById<Button>(R.id.btnProducts)
+
+        // Застосовуємо масштаб до тексту на кнопках
+        btnOrders.textSize = btnOrders.textSize * scale
+        btnSent.textSize = btnSent.textSize * scale
+        btnSettings.textSize = btnSettings.textSize * scale
+        btnProducts.textSize = btnProducts.textSize * scale
+
+        // Додаємо обробники натискань
+        btnOrders.setOnClickListener {
             // TODO: коли буде створено екран замовлень, тут відкрити його через Intent
             // startActivity(Intent(this, OrdersActivity::class.java))
         }
 
         // Аналогічно отримуємо кнопку відправлених документів
         // та навішуємо на неї обробник натискання
-        findViewById<Button>(R.id.btnSent).setOnClickListener {
+        btnSent.setOnClickListener {
             // TODO: реалізувати відкриття відповідної активності
             // startActivity(Intent(this, SentActivity::class.java))
         }
 
         // Кнопка "Налаштування" відкриває екран SettingsActivity
-        findViewById<Button>(R.id.btnSettings).setOnClickListener {
+        btnSettings.setOnClickListener {
             // Запускаємо активність налаштувань через Intent
             startActivity(Intent(this, SettingsActivity::class.java))
         }
 
         // Кнопка "Товари" відкриває новий екран зі списком товарів
-        findViewById<Button>(R.id.btnProducts).setOnClickListener {
+        btnProducts.setOnClickListener {
             // Створюємо Intent для запуску ProductListActivity
             val intent = Intent(this, ProductListActivity::class.java)
             startActivity(intent)

--- a/app/src/main/java/ua/company/tzd/ProductListActivity.kt
+++ b/app/src/main/java/ua/company/tzd/ProductListActivity.kt
@@ -65,7 +65,11 @@ class ProductListActivity : AppCompatActivity() {
                 val port = prefs.getInt("ftpPort", 21)
                 val user = prefs.getString("ftpUser", "") ?: ""
                 val pass = prefs.getString("ftpPass", "") ?: ""
-
+                // Каталог, у якому розміщено файл products.xml на сервері
+                val importDir = prefs.getString("ftp_import_dir", "") ?: ""
+                // Масштаб шрифту для відображення тексту
+                val scale = prefs.getInt("ui_font_scale", 100) / 100.0f
+                
                 // Підключаємося до FTP-сервера за отриманими реквізитами
                 ftpClient.connect(InetAddress.getByName(host), port)
 
@@ -75,8 +79,8 @@ class ProductListActivity : AppCompatActivity() {
                     ftpClient.enterLocalPassiveMode()
                     ftpClient.setFileType(FTPClient.BINARY_FILE_TYPE)
 
-                    // Витягаємо файл products.xml з кореня FTP
-                    val inputStream: InputStream = ftpClient.retrieveFileStream("/products.xml")
+                    // Витягаємо файл products.xml з вказаної у налаштуваннях папки
+                    val inputStream: InputStream = ftpClient.retrieveFileStream(importDir + "/products.xml")
 
                     // Створюємо XML парсер для читання файлу
                     val factory = XmlPullParserFactory.newInstance()
@@ -135,6 +139,15 @@ class ProductListActivity : AppCompatActivity() {
 
                             tvCode.text = c
                             tvName.text = n
+
+                            // Дозволяємо перенесення довгих назв на кілька рядків
+                            tvName.setSingleLine(false)
+                            tvName.setMaxLines(3)
+                            tvName.ellipsize = null
+
+                            // Застосовуємо масштабування тексту згідно з налаштуваннями
+                            tvCode.textSize = tvCode.textSize * scale
+                            tvName.textSize = tvName.textSize * scale
 
                             // Невеликий відступ для кращого вигляду
                             tvCode.setPadding(16, 16, 16, 16)

--- a/app/src/main/java/ua/company/tzd/SettingsActivity.kt
+++ b/app/src/main/java/ua/company/tzd/SettingsActivity.kt
@@ -46,8 +46,16 @@ class SettingsActivity : AppCompatActivity() {
         val ftpImportDir = findViewById<EditText>(R.id.inputFtpImportDir)
         val ftpExportDir = findViewById<EditText>(R.id.inputFtpExportDir)
 
+        // Поле масштабу шрифту інтерфейсу
+        val inputFontScale = findViewById<EditText>(R.id.inputFontScale)
+
         val btnSave = findViewById<Button>(R.id.btnSaveSettings)
         val btnTestFtp = findViewById<Button>(R.id.btnTestFtp)
+
+        // Зчитуємо масштаб шрифту та застосовуємо до кнопок
+        val scale = prefs.getInt("ui_font_scale", 100) / 100.0f
+        btnSave.textSize = btnSave.textSize * scale
+        btnTestFtp.textSize = btnTestFtp.textSize * scale
 
         // Завантажуємо збережені значення або підставляємо типові
         codeStart.setText(prefs.getInt("codeStart", 0).toString())
@@ -64,6 +72,11 @@ class SettingsActivity : AppCompatActivity() {
         ftpPort.setText(prefs.getInt("ftpPort", 21).toString())
         ftpUser.setText(prefs.getString("ftpUser", ""))
         ftpPass.setText(prefs.getString("ftpPass", ""))
+        ftpImportDir.setText(prefs.getString("ftp_import_dir", ""))
+        ftpExportDir.setText(prefs.getString("ftp_export_dir", ""))
+
+        // Значення масштабу шрифту, 100% за замовчуванням
+        inputFontScale.setText(prefs.getInt("ui_font_scale", 100).toString())
 
         // Зберігаємо введені дані у SharedPreferences
         btnSave.setOnClickListener {
@@ -81,6 +94,9 @@ class SettingsActivity : AppCompatActivity() {
                 putInt("ftpPort", ftpPort.text.toString().toInt())
                 putString("ftpUser", ftpUser.text.toString())
                 putString("ftpPass", ftpPass.text.toString())
+                putString("ftp_import_dir", ftpImportDir.text.toString())
+                putString("ftp_export_dir", ftpExportDir.text.toString())
+                putInt("ui_font_scale", inputFontScale.text.toString().toInt())
                 apply()
             }
             Toast.makeText(this, "Налаштування збережено", Toast.LENGTH_SHORT).show()

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -8,28 +8,62 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <!-- Штрихкод -->
-        <TextView android:text="Код товару:" android:layout_width="wrap_content" android:layout_height="wrap_content"/>
-        <EditText android:id="@+id/inputCodeStart" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="Початок"/>
-        <EditText android:id="@+id/inputCodeLength" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="Довжина"/>
+        <!-- Заголовок секції налаштувань сканера -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Сканер"
+            android:textStyle="bold"
+            android:paddingTop="16dp" />
 
-        <TextView android:text="Вага (кг):" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="16dp"/>
-        <EditText android:id="@+id/inputWeightKgStart" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="Початок"/>
-        <EditText android:id="@+id/inputWeightKgLength" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="Довжина"/>
+        <!-- Таблиця з параметрами штрихкоду -->
+        <GridLayout
+            android:id="@+id/scannerSettingsGrid"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:columnCount="3"
+            android:padding="8dp">
 
-        <TextView android:text="Вага (г):" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="16dp"/>
-        <EditText android:id="@+id/inputWeightGrStart" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="Початок"/>
-        <EditText android:id="@+id/inputWeightGrLength" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="Довжина"/>
+            <!-- Заголовки колонок -->
+            <TextView android:text="Параметр" />
+            <TextView android:text="Початок" />
+            <TextView android:text="Довжина" />
 
-        <TextView android:text="Кількість упаковок:" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="16dp"/>
-        <EditText android:id="@+id/inputCountStart" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="Початок"/>
-        <EditText android:id="@+id/inputCountLength" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="Довжина"/>
+            <!-- Код товару -->
+            <TextView android:text="Код товару" />
+            <EditText android:id="@+id/inputCodeStart" android:layout_width="match_parent" android:layout_height="wrap_content" />
+            <EditText android:id="@+id/inputCodeLength" android:layout_width="match_parent" android:layout_height="wrap_content" />
 
-        <TextView android:text="Затримка після сканування (мс):" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="16dp"/>
+            <!-- Кількість упаковок -->
+            <TextView android:text="К-сть упаковок" />
+            <EditText android:id="@+id/inputCountStart" android:layout_width="match_parent" android:layout_height="wrap_content" />
+            <EditText android:id="@+id/inputCountLength" android:layout_width="match_parent" android:layout_height="wrap_content" />
+
+            <!-- Вага (кг) -->
+            <TextView android:text="Вага (кг)" />
+            <EditText android:id="@+id/inputWeightKgStart" android:layout_width="match_parent" android:layout_height="wrap_content" />
+            <EditText android:id="@+id/inputWeightKgLength" android:layout_width="match_parent" android:layout_height="wrap_content" />
+
+            <!-- Вага (г) -->
+            <TextView android:text="Вага (г)" />
+            <EditText android:id="@+id/inputWeightGrStart" android:layout_width="match_parent" android:layout_height="wrap_content" />
+            <EditText android:id="@+id/inputWeightGrLength" android:layout_width="match_parent" android:layout_height="wrap_content" />
+
+        </GridLayout>
+
+        <!-- Затримка після сканування у мілісекундах -->
+        <TextView android:text="Затримка після сканування (мс):" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="8dp"/>
         <EditText android:id="@+id/inputDelay" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="2000"/>
 
-        <!-- FTP -->
-        <TextView android:text="FTP сервер:" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="24dp"/>
+        <!-- Заголовок секції FTP -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="FTP"
+            android:textStyle="bold"
+            android:paddingTop="16dp" />
+
+        <TextView android:text="FTP сервер:" android:layout_width="wrap_content" android:layout_height="wrap_content"/>
         <EditText android:id="@+id/inputFtpHost" android:layout_width="match_parent" android:layout_height="wrap_content" android:hint="ftp.example.com"/>
 
         <TextView android:text="FTP порт:" android:layout_width="wrap_content" android:layout_height="wrap_content"/>
@@ -54,6 +88,21 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="Каталог експорту" />
+
+        <!-- Заголовок секції "Інтерфейс" -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Інтерфейс"
+            android:textStyle="bold"
+            android:paddingTop="16dp" />
+
+        <!-- Поле для введення масштабу шрифту у відсотках -->
+        <EditText
+            android:id="@+id/inputFontScale"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Зум (%)" />
 
         <Button
             android:id="@+id/btnTestFtp"


### PR DESCRIPTION
## Summary
- support configurable FTP import directory in product list
- wrap long product names and scale text sizes from settings
- allow zoom percentage setting, add UI headers and grid layout
- apply font scale to buttons across activities

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b38dcf6088320bbab3835836c8439