### PR TITLE
Implement separate text and button scaling

### DIFF
--- a/app/src/main/java/ua/company/tzd/MainActivity.kt
+++ b/app/src/main/java/ua/company/tzd/MainActivity.kt
@@ -3,7 +3,6 @@ package ua.company.tzd
 import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
-import androidx.preference.PreferenceManager
 import ua.company.tzd.utils.TextScaleHelper
 // AppCompatActivity міститься у бібліотеці appcompat, яка додає підтримку
 // сучасних можливостей на старіших версіях Android
@@ -19,14 +18,9 @@ class MainActivity : AppCompatActivity() {
         // Підключаємо файл розмітки activity_main.xml як вигляд для цієї активності
         setContentView(R.layout.activity_main)
 
-        // Зчитуємо масштаб шрифту з налаштувань користувача через PreferenceManager
-        // Значення зберігається у відсотках, тому ділимо на 100
-        val zoom = PreferenceManager.getDefaultSharedPreferences(this)
-            .getInt("font_zoom", 100)
-        val scale = zoom / 100f
-
-        // Застосовуємо масштабування до усіх елементів інтерфейсу за один виклик
-        TextScaleHelper.applyTextScale(this, findViewById(android.R.id.content), scale)
+        // Масштабування всього інтерфейсу виконуємо через допоміжний клас.
+        // Метод сам зчитає потрібні значення з налаштувань користувача.
+        TextScaleHelper.applyTextScale(this, findViewById(android.R.id.content))
 
         // Отримуємо кнопки з розмітки
         val btnOrders = findViewById<Button>(R.id.btnOrders)

--- a/app/src/main/java/ua/company/tzd/ProductListActivity.kt
+++ b/app/src/main/java/ua/company/tzd/ProductListActivity.kt
@@ -7,6 +7,8 @@ import android.widget.TableRow
 import android.widget.TextView
 import androidx.preference.PreferenceManager
 import androidx.appcompat.app.AppCompatActivity
+import android.util.TypedValue
+import ua.company.tzd.utils.TextScaleHelper
 import ua.company.tzd.utils.dpToPx
 import org.apache.commons.net.ftp.FTPClient
 import org.xmlpull.v1.XmlPullParser
@@ -32,6 +34,9 @@ class ProductListActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         // Підключаємо розмітку activity_product_list.xml
         setContentView(R.layout.activity_product_list)
+
+        // Масштабуємо усі елементи згідно з налаштуваннями користувача
+        TextScaleHelper.applyTextScale(this, findViewById(android.R.id.content))
 
         // Знаходимо таблицю у розмітці за її ID
         tableLayout = findViewById(R.id.tableLayoutProducts)
@@ -69,7 +74,7 @@ class ProductListActivity : AppCompatActivity() {
                 // Каталог, у якому розміщено файл products.xml на сервері
                 val importDir = prefs.getString("ftp_import_dir", "") ?: ""
                 // Масштаб шрифту для відображення тексту
-                val scale = prefs.getInt("font_zoom", 100) / 100.0f
+                val scale = TextScaleHelper.getTextScale(this)
                 
                 // Підключаємося до FTP-сервера за отриманими реквізитами
                 ftpClient.connect(InetAddress.getByName(host), port)
@@ -147,15 +152,23 @@ class ProductListActivity : AppCompatActivity() {
                             tvName.ellipsize = null
 
                             // Застосовуємо масштабування тексту згідно з налаштуваннями
-                            tvCode.textSize = tvCode.textSize * scale
-                            tvName.textSize = tvName.textSize * scale
+                            val baseCode = tvCode.textSize / resources.configuration.fontScale
+                            val baseName = tvName.textSize / resources.configuration.fontScale
+                            tvCode.setTextSize(
+                                TypedValue.COMPLEX_UNIT_PX,
+                                baseCode * TextScaleHelper.getTextScale(this@ProductListActivity)
+                            )
+                            tvName.setTextSize(
+                                TypedValue.COMPLEX_UNIT_PX,
+                                baseName * TextScaleHelper.getTextScale(this@ProductListActivity)
+                            )
 
                             // Невеликий відступ для кращого вигляду
                             tvCode.setPadding(16, 16, 16, 16)
                             tvName.setPadding(16, 16, 16, 16)
 
                             // Першу колонку робимо вузькою, а другу розтягуємо на решту ширини
-                            tvCode.layoutParams = TableRow.LayoutParams(40.dpToPx(this), TableRow.LayoutParams.WRAP_CONTENT)
+                            tvCode.layoutParams = TableRow.LayoutParams(48.dpToPx(this), TableRow.LayoutParams.WRAP_CONTENT)
                             tvName.layoutParams = TableRow.LayoutParams(0, TableRow.LayoutParams.WRAP_CONTENT, 1f)
 
                             row.addView(tvCode)

--- a/app/src/main/java/ua/company/tzd/SettingsActivity.kt
+++ b/app/src/main/java/ua/company/tzd/SettingsActivity.kt
@@ -50,15 +50,15 @@ class SettingsActivity : AppCompatActivity() {
         val ftpImportDir = findViewById<EditText>(R.id.inputFtpImportDir)
         val ftpExportDir = findViewById<EditText>(R.id.inputFtpExportDir)
 
-        // Поле масштабу шрифту інтерфейсу
-        val inputFontScale = findViewById<EditText>(R.id.inputFontScale)
+        // Поля масштабування тексту та кнопок
+        val inputTextZoom = findViewById<EditText>(R.id.inputTextZoomPercent)
+        val inputButtonZoom = findViewById<EditText>(R.id.inputButtonZoomPercent)
 
         val btnSave = findViewById<Button>(R.id.btnSaveSettings)
         val btnTestFtp = findViewById<Button>(R.id.btnTestFtp)
 
-        // Зчитуємо масштаб шрифту та одразу масштабуємо усі елементи на екрані
-        val scale = prefs.getInt("font_zoom", 100) / 100.0f
-        TextScaleHelper.applyTextScale(this, findViewById(android.R.id.content), scale)
+        // Масштабуємо весь інтерфейс згідно з налаштуваннями
+        TextScaleHelper.applyTextScale(this, findViewById(android.R.id.content))
 
         // Задаємо фіксовану ширину полям числових значень (до 3 символів)
         val numericWidth = 40.dpToPx(this)
@@ -85,8 +85,9 @@ class SettingsActivity : AppCompatActivity() {
         ftpImportDir.setText(prefs.getString("ftp_import_dir", ""))
         ftpExportDir.setText(prefs.getString("ftp_export_dir", ""))
 
-        // Значення масштабу шрифту, 100% за замовчуванням
-        inputFontScale.setText(prefs.getInt("font_zoom", 100).toString())
+        // Значення масштабів, 100% за замовчуванням
+        inputTextZoom.setText(prefs.getInt("textZoomPercent", 100).toString())
+        inputButtonZoom.setText(prefs.getInt("buttonZoomPercent", 100).toString())
 
         // Зберігаємо введені дані у SharedPreferences
         btnSave.setOnClickListener {
@@ -106,7 +107,8 @@ class SettingsActivity : AppCompatActivity() {
                 putString("ftpPass", ftpPass.text.toString())
                 putString("ftp_import_dir", ftpImportDir.text.toString())
                 putString("ftp_export_dir", ftpExportDir.text.toString())
-                putInt("font_zoom", inputFontScale.text.toString().toInt())
+                putInt("textZoomPercent", inputTextZoom.text.toString().toInt())
+                putInt("buttonZoomPercent", inputButtonZoom.text.toString().toInt())
                 apply()
             }
             Toast.makeText(this, "Налаштування збережено", Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/ua/company/tzd/utils/TextScaleHelper.kt
+++ b/app/src/main/java/ua/company/tzd/utils/TextScaleHelper.kt
@@ -3,8 +3,11 @@ package ua.company.tzd.utils
 import android.content.Context
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 import android.widget.TextView
 import androidx.core.view.children
+import androidx.preference.PreferenceManager
+import android.util.TypedValue
 
 /**
  * Допоміжний об'єкт для зміни розміру тексту у всіх вкладених елементах.
@@ -12,24 +15,50 @@ import androidx.core.view.children
  * шрифти усіх кнопок чи текстових полів в активності.
  */
 object TextScaleHelper {
+
+    /**
+     * Повертає коефіцієнт масштабування звичайного тексту з налаштувань.
+     * Значення зберігається у відсотках, тому ділимо на 100.
+     */
+    fun getTextScale(context: Context): Float {
+        val percent = PreferenceManager.getDefaultSharedPreferences(context)
+            .getInt("textZoomPercent", 100)
+        return percent / 100f
+    }
+
+    /**
+     * Повертає коефіцієнт масштабування для кнопок з налаштувань.
+     * Так само ділиться на 100, щоб отримати множник.
+     */
+    fun getButtonScale(context: Context): Float {
+        val percent = PreferenceManager.getDefaultSharedPreferences(context)
+            .getInt("buttonZoomPercent", 100)
+        return percent / 100f
+    }
+
     /**
      * Рекурсивно проходить по всій ієрархії view та масштабує
-     * розмір тексту для кожного TextView.
+     * розмір тексту для кожного TextView або Button.
+     * Метод сам зчитує потрібний коефіцієнт масштабування з налаштувань.
      *
      * @param context контекст, потрібний для перерахунку одиниць виміру
      * @param root кореневий елемент, з якого починаємо обходити дочірні
-     * @param scale коефіцієнт масштабування (1f означає 100 % розміру)
      */
-    fun applyTextScale(context: Context, root: View, scale: Float) {
+    fun applyTextScale(context: Context, root: View) {
         when (root) {
+            is Button -> {
+                val scale = getButtonScale(context)
+                val base = root.textSize / context.resources.configuration.fontScale
+                root.setTextSize(TypedValue.COMPLEX_UNIT_PX, base * scale)
+            }
             is TextView -> {
-                // textSize повертає значення в пікселях, тому переводимо його
-                // з урахуванням щільності екрану
-                root.textSize = root.textSize * scale / context.resources.displayMetrics.scaledDensity
+                val scale = getTextScale(context)
+                val base = root.textSize / context.resources.configuration.fontScale
+                root.setTextSize(TypedValue.COMPLEX_UNIT_PX, base * scale)
             }
             is ViewGroup -> {
                 // Якщо елемент містить дітей, обходимо кожного з них
-                root.children.forEach { applyTextScale(context, it, scale) }
+                root.children.forEach { applyTextScale(context, it) }
             }
         }
     }

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -31,9 +31,8 @@
 
             <TableRow>
                 <TextView
-                    android:layout_width="0dp"
+                    android:layout_width="80dp"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
                     android:text="Параметр" />
                 <TextView
                     android:layout_width="40dp"
@@ -49,9 +48,8 @@
 
             <TableRow>
                 <TextView
-                    android:layout_width="0dp"
+                    android:layout_width="80dp"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
                     android:text="Код товару" />
                 <EditText
                     android:id="@+id/inputCodeStart"
@@ -65,9 +63,8 @@
 
             <TableRow>
                 <TextView
-                    android:layout_width="0dp"
+                    android:layout_width="80dp"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
                     android:text="К-сть упаковок" />
                 <EditText
                     android:id="@+id/inputCountStart"
@@ -81,9 +78,8 @@
 
             <TableRow>
                 <TextView
-                    android:layout_width="0dp"
+                    android:layout_width="80dp"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
                     android:text="Вага (кг)" />
                 <EditText
                     android:id="@+id/inputWeightKgStart"
@@ -97,9 +93,8 @@
 
             <TableRow>
                 <TextView
-                    android:layout_width="0dp"
+                    android:layout_width="80dp"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
                     android:text="Вага (г)" />
                 <EditText
                     android:id="@+id/inputWeightGrStart"
@@ -151,20 +146,29 @@
             android:layout_height="wrap_content"
             android:hint="Каталог експорту" />
 
-        <!-- Заголовок секції "Інтерфейс" -->
+        <!-- Заголовок секції "Масштаб" -->
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Інтерфейс"
+            android:text="Масштаб"
             android:textStyle="bold"
             android:paddingTop="16dp" />
 
-        <!-- Поле для введення масштабу шрифту у відсотках -->
+        <!-- Масштаб тексту у відсотках -->
         <EditText
-            android:id="@+id/inputFontScale"
+            android:id="@+id/inputTextZoomPercent"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Зум (%)" />
+            android:hint="Масштаб тексту (%)"
+            android:inputType="number" />
+
+        <!-- Масштаб кнопок у відсотках -->
+        <EditText
+            android:id="@+id/inputButtonZoomPercent"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Масштаб кнопок (%)"
+            android:inputType="number" />
 
         <Button
             android:id="@+id/btnTestFtp"


### PR DESCRIPTION
## Summary
- add helpers for text and button scaling
- store text and button scale settings
- apply scaling through `TextScaleHelper`
- narrow first column in scanner settings
- expose new scaling inputs in settings

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b49d81cb48320a4f1849f51641a27