### PR TITLE
Add driver and orders screens

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,6 +45,8 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.preference)
+    implementation(libs.androidx.recyclerview)
+    implementation(libs.androidx.swiperefreshlayout)
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.ui)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,8 @@
         android:usesCleartextTraffic="true"
         android:theme="@style/Theme.TZD">
         <activity android:name=".SettingsActivity" />
+        <activity android:name=".ui.orders.DriversActivity" />
+        <activity android:name=".ui.orders.OrdersActivity" />
         <!-- Активність зі списком товарів -->
         <activity android:name=".ProductListActivity" />
         <activity

--- a/app/src/main/java/ua/company/tzd/MainActivity.kt
+++ b/app/src/main/java/ua/company/tzd/MainActivity.kt
@@ -44,8 +44,8 @@ class MainActivity : AppCompatActivity() {
 
         // Додаємо обробники натискань
         btnOrders.setOnClickListener {
-            // TODO: коли буде створено екран замовлень, тут відкрити його через Intent
-            // startActivity(Intent(this, OrdersActivity::class.java))
+            // Відкриваємо екран зі списком водіїв та їх замовлень
+            startActivity(Intent(this, ua.company.tzd.ui.orders.DriversActivity::class.java))
         }
 
         // Аналогічно отримуємо кнопку відправлених документів

--- a/app/src/main/java/ua/company/tzd/ui/orders/DriversActivity.kt
+++ b/app/src/main/java/ua/company/tzd/ui/orders/DriversActivity.kt
@@ -1,0 +1,150 @@
+package ua.company.tzd.ui.orders
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import org.xmlpull.v1.XmlPullParser
+import org.xmlpull.v1.XmlPullParserFactory
+import ua.company.tzd.R
+import ua.company.tzd.utils.TextScaleHelper
+import java.io.File
+
+/**
+ * Екран зі списком усіх водіїв, знайдених у локальних файлах замовлень.
+ */
+class DriversActivity : AppCompatActivity() {
+
+    /** Список, що відображаємо у RecyclerView */
+    private val drivers = mutableListOf<String>()
+
+    /** Адаптер для RecyclerView */
+    private lateinit var adapter: DriversAdapter
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_drivers)
+
+        // Масштабуємо інтерфейс згідно з налаштуваннями користувача
+        TextScaleHelper.applyTextScale(this, findViewById(android.R.id.content))
+
+        // Налаштовуємо список водіїв
+        val recycler = findViewById<RecyclerView>(R.id.recyclerViewDrivers)
+        recycler.layoutManager = LinearLayoutManager(this)
+        adapter = DriversAdapter(drivers) { driver ->
+            // При виборі водія відкриваємо нову активність зі списком його замовлень
+            val intent = Intent(this, OrdersActivity::class.java)
+            intent.putExtra("driver", driver)
+            startActivity(intent)
+        }
+        recycler.adapter = adapter
+
+        // Обробка жесту "потягни, щоб оновити"
+        val swipeLayout = findViewById<SwipeRefreshLayout>(R.id.swipeRefreshLayout)
+        swipeLayout.setOnRefreshListener {
+            loadDrivers()
+            swipeLayout.isRefreshing = false
+        }
+
+        // Кнопка повернення на попередній екран
+        findViewById<Button>(R.id.btnBack).setOnClickListener { finish() }
+        // Кнопка примусового перезавантаження списку
+        findViewById<Button>(R.id.btnRefresh).setOnClickListener { loadDrivers() }
+
+        // Вперше завантажуємо дані при створенні активності
+        loadDrivers()
+    }
+
+    /**
+     * Скануємо локальну папку "orders" та формуємо унікальний список водіїв.
+     */
+    private fun loadDrivers() {
+        val ordersDir = File(filesDir, "orders")
+        val foundDrivers = mutableSetOf<String>()
+
+        if (ordersDir.exists()) {
+            ordersDir.listFiles()?.forEach { file ->
+                if (file.extension == "xml") {
+                    // Зчитуємо тег <водій> з поточного файлу
+                    parseDriverTag(file)?.let { foundDrivers.add(it) }
+                }
+            }
+        }
+
+        // Оновлюємо дані адаптера
+        drivers.clear()
+        drivers.addAll(foundDrivers.sorted())
+        adapter.notifyDataSetChanged()
+    }
+
+    /**
+     * Повертає значення тегу <водій> з переданого XML-файлу, якщо такий існує.
+     */
+    private fun parseDriverTag(file: File): String? {
+        return try {
+            val factory = XmlPullParserFactory.newInstance()
+            val parser = factory.newPullParser()
+            parser.setInput(file.inputStream(), null)
+
+            var event = parser.eventType
+            var driver: String? = null
+            while (event != XmlPullParser.END_DOCUMENT) {
+                if (event == XmlPullParser.START_TAG && parser.name == "водій") {
+                    driver = parser.nextText()
+                    break
+                }
+                event = parser.next()
+            }
+            driver
+        } catch (e: Exception) {
+            // У випадку помилки просто виводимо її у консоль
+            e.printStackTrace()
+            null
+        }
+    }
+
+    /**
+     * Простий адаптер, який показує список рядків та передає натискання назовні.
+     */
+    private class DriversAdapter(
+        private val items: List<String>,
+        private val onClick: (String) -> Unit
+    ) : RecyclerView.Adapter<DriversAdapter.ViewHolder>() {
+
+        /** ViewHolder містить посилання на елемент списку */
+        class ViewHolder(view: View, val onClick: (String) -> Unit) : RecyclerView.ViewHolder(view) {
+            private val text: TextView = view.findViewById(android.R.id.text1)
+            private var current: String? = null
+
+            init {
+                view.setOnClickListener {
+                    current?.let { onClick(it) }
+                }
+            }
+
+            fun bind(name: String) {
+                current = name
+                text.text = name
+            }
+        }
+
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+            val view = LayoutInflater.from(parent.context)
+                .inflate(android.R.layout.simple_list_item_1, parent, false)
+            return ViewHolder(view, onClick)
+        }
+
+        override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+            holder.bind(items[position])
+        }
+
+        override fun getItemCount(): Int = items.size
+    }
+}

--- a/app/src/main/java/ua/company/tzd/ui/orders/OrdersActivity.kt
+++ b/app/src/main/java/ua/company/tzd/ui/orders/OrdersActivity.kt
@@ -1,0 +1,105 @@
+package ua.company.tzd.ui.orders
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import org.xmlpull.v1.XmlPullParser
+import org.xmlpull.v1.XmlPullParserFactory
+import ua.company.tzd.R
+import ua.company.tzd.utils.TextScaleHelper
+import java.io.File
+
+/**
+ * Показує список замовлень, що належать обраному водію.
+ */
+class OrdersActivity : AppCompatActivity() {
+
+    private val orders = mutableListOf<File>()
+    private lateinit var adapter: OrdersAdapter
+    private lateinit var driverName: String
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_orders)
+
+        // Масштабуємо усі елементи інтерфейсу
+        TextScaleHelper.applyTextScale(this, findViewById(android.R.id.content))
+
+        driverName = intent.getStringExtra("driver") ?: ""
+
+        val recycler = findViewById<RecyclerView>(R.id.recyclerViewOrders)
+        recycler.layoutManager = LinearLayoutManager(this)
+        adapter = OrdersAdapter(orders)
+        recycler.adapter = adapter
+
+        findViewById<Button>(R.id.btnBack).setOnClickListener { finish() }
+
+        loadOrders()
+    }
+
+    /** Завантажуємо всі замовлення для переданого водія */
+    private fun loadOrders() {
+        val ordersDir = File(filesDir, "orders")
+        val list = mutableListOf<File>()
+
+        if (ordersDir.exists()) {
+            ordersDir.listFiles()?.forEach { file ->
+                if (file.extension == "xml" && parseDriverTag(file) == driverName) {
+                    list.add(file)
+                }
+            }
+        }
+
+        orders.clear()
+        orders.addAll(list)
+        adapter.notifyDataSetChanged()
+    }
+
+    /** Пошук значення тегу <водій> у файлі замовлення */
+    private fun parseDriverTag(file: File): String? {
+        return try {
+            val parser = XmlPullParserFactory.newInstance().newPullParser()
+            parser.setInput(file.inputStream(), null)
+            var event = parser.eventType
+            var driver: String? = null
+            while (event != XmlPullParser.END_DOCUMENT) {
+                if (event == XmlPullParser.START_TAG && parser.name == "водій") {
+                    driver = parser.nextText()
+                    break
+                }
+                event = parser.next()
+            }
+            driver
+        } catch (e: Exception) {
+            e.printStackTrace()
+            null
+        }
+    }
+
+    /** Адаптер для відображення імен файлів замовлень */
+    private class OrdersAdapter(private val items: List<File>) :
+        RecyclerView.Adapter<OrdersAdapter.ViewHolder>() {
+
+        class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+            val text: TextView = view.findViewById(android.R.id.text1)
+        }
+
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+            val view = LayoutInflater.from(parent.context)
+                .inflate(android.R.layout.simple_list_item_1, parent, false)
+            return ViewHolder(view)
+        }
+
+        override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+            holder.text.text = items[position].name
+        }
+
+        override fun getItemCount(): Int = items.size
+    }
+}

--- a/app/src/main/res/layout/activity_drivers.xml
+++ b/app/src/main/res/layout/activity_drivers.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <!-- Область зі списком, яку можна оновити свайпом вниз -->
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipeRefreshLayout"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <!-- Список водіїв -->
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerViewDrivers"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+    <!-- Нижній ряд з кнопками навігації -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_gravity="bottom"
+        android:gravity="center"
+        android:padding="16dp">
+
+        <Button
+            android:id="@+id/btnBack"
+            style="@style/CustomButton"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:text="Назад"
+            android:layout_marginEnd="8dp"/>
+
+        <Button
+            android:id="@+id/btnRefresh"
+            style="@style/CustomButton"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:text="Оновити"
+            android:layout_marginStart="8dp"/>
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -11,6 +11,7 @@
     <!-- Кнопка для відкриття списку замовлень -->
     <Button
         android:id="@+id/btnOrders"
+        style="@style/CustomButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Замовлення" />
@@ -18,6 +19,7 @@
     <!-- Кнопка для перегляду відправлених позицій -->
     <Button
         android:id="@+id/btnSent"
+        style="@style/CustomButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Відправлені"
@@ -26,6 +28,7 @@
     <!-- Кнопка для переходу в налаштування програми -->
     <Button
         android:id="@+id/btnSettings"
+        style="@style/CustomButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Налаштування"
@@ -34,6 +37,7 @@
     <!-- Кнопка для перегляду списку товарів -->
     <Button
         android:id="@+id/btnProducts"
+        style="@style/CustomButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Товари"

--- a/app/src/main/res/layout/activity_orders.xml
+++ b/app/src/main/res/layout/activity_orders.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerViewOrders"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+    <Button
+        android:id="@+id/btnBack"
+        style="@style/CustomButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Назад"
+        android:layout_margin="16dp" />
+</LinearLayout>

--- a/app/src/main/res/layout/activity_product_list.xml
+++ b/app/src/main/res/layout/activity_product_list.xml
@@ -24,6 +24,7 @@
 
         <Button
             android:id="@+id/btnRefresh"
+            style="@style/CustomButton"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
@@ -31,6 +32,7 @@
 
         <Button
             android:id="@+id/btnBack"
+            style="@style/CustomButton"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -235,6 +235,7 @@
 
         <Button
             android:id="@+id/btnTestFtp"
+            style="@style/CustomButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Перевірити FTP"
@@ -249,12 +250,14 @@
 
             <Button
                 android:id="@+id/btnBack"
+                style="@style/CustomButton"
                 android:text="НАЗАД"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content" />
 
             <Button
                 android:id="@+id/btnSave"
+                style="@style/CustomButton"
                 android:text="ЗБЕРЕГТИ"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Спільний стиль для всіх кнопок з ефектом натискання -->
+    <style name="CustomButton" parent="Widget.AppCompat.Button">
+        <item name="android:background">?attr/selectableItemBackground</item>
+        <item name="android:clickable">true</item>
+        <item name="android:focusable">true</item>
+    </style>
+</resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,8 @@ activityCompose = "1.10.1"
 composeBom = "2024.09.00"
 appCompat = "1.7.0"
 preference = "1.2.1"
+recyclerView = "1.3.2"
+swipeRefreshLayout = "1.1.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -28,6 +30,8 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appCompat" }
 androidx-preference = { group = "androidx.preference", name = "preference", version.ref = "preference" }
+androidx-recyclerview = { group = "androidx.recyclerview", name = "recyclerview", version.ref = "recyclerView" }
+androidx-swiperefreshlayout = { group = "androidx.swiperefreshlayout", name = "swiperefreshlayout", version.ref = "swipeRefreshLayout" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- create DriversActivity and OrdersActivity to browse local order files
- add swipe-to-refresh with bottom buttons
- include CustomButton style
- apply button style across layouts
- wire main screen to new activities
- add RecyclerView and SwipeRefreshLayout dependencies

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688b7cae4314832099f5dcbaf4b837e7