### PR TITLE
Improve drivers loading when folder empty

### DIFF
--- a/app/src/main/java/ua/company/tzd/ui/orders/DriversActivity.kt
+++ b/app/src/main/java/ua/company/tzd/ui/orders/DriversActivity.kt
@@ -66,22 +66,29 @@ class DriversActivity : AppCompatActivity() {
      * Скануємо локальну папку "orders" та формуємо унікальний список водіїв.
      */
     private fun loadDrivers() {
+        // Папка, де зберігаються файли замовлень
         val ordersDir = File(filesDir, "orders")
+        // Множина для збирання унікальних імен водіїв
         val foundDrivers = mutableSetOf<String>()
 
-        if (ordersDir.exists()) {
-            ordersDir.listFiles()?.forEach { file ->
-                if (file.extension == "xml") {
-                    // Зчитуємо тег <водій> з поточного файлу
-                    parseDriverTag(file)?.let { foundDrivers.add(it) }
-                }
+        // Перевіряємо, що папка існує і це саме каталог
+        if (ordersDir.exists() && ordersDir.isDirectory) {
+            // Отримуємо список лише xml-файлів або порожній список, якщо файлів немає
+            val xmlFiles = ordersDir.listFiles()?.filter { it.extension == "xml" } ?: emptyList()
+            // Проходимося по кожному файлу та шукаємо тег <водій>
+            xmlFiles.forEach { file ->
+                parseDriverTag(file)?.let { foundDrivers.add(it) }
             }
         }
 
-        // Оновлюємо дані адаптера
+        // Оновлюємо список, який використовується адаптером
         drivers.clear()
         drivers.addAll(foundDrivers.sorted())
         adapter.notifyDataSetChanged()
+
+        // Показуємо підказку, якщо водіїв не знайдено
+        val emptyView = findViewById<TextView>(R.id.emptyTextView)
+        emptyView.visibility = if (drivers.isEmpty()) View.VISIBLE else View.GONE
     }
 
     /**

--- a/app/src/main/res/layout/activity_drivers.xml
+++ b/app/src/main/res/layout/activity_drivers.xml
@@ -18,6 +18,18 @@
             android:layout_height="match_parent" />
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
+    <!-- Повідомлення, яке показується, якщо замовлення не знайдено -->
+    <TextView
+        android:id="@+id/emptyTextView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:gravity="center"
+        android:text="Жодного замовлення не знайдено"
+        android:textColor="@android:color/darker_gray"
+        android:textSize="18sp"
+        android:visibility="gone" />
+
     <!-- Нижній ряд з кнопками навігації -->
     <LinearLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
## Summary
- show hint when orders folder doesn't exist or is empty
- guard driver loading against missing files
- add empty state TextView in drivers screen

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688b85421c088320a34eacfa9bb78341