### PR TITLE
Implement order locking and add padding

### DIFF
--- a/app/src/main/java/ua/company/tzd/SettingsActivity.kt
+++ b/app/src/main/java/ua/company/tzd/SettingsActivity.kt
@@ -46,9 +46,10 @@ class SettingsActivity : AppCompatActivity() {
         val ftpPort = findViewById<EditText>(R.id.inputFtpPort)
         val ftpUser = findViewById<EditText>(R.id.inputFtpUser)
         val ftpPass = findViewById<EditText>(R.id.inputFtpPass)
-        // Нові поля з папками імпорту та експорту на FTP-сервері
+        // Нові поля з папками імпорту, експорту та обробки на FTP-сервері
         val ftpImportDir = findViewById<EditText>(R.id.inputFtpImportDir)
         val ftpExportDir = findViewById<EditText>(R.id.inputFtpExportDir)
+        val ftpProcessingDir = findViewById<EditText>(R.id.inputFtpProcessingDir)
 
         // Поля масштабування тексту та кнопок
         val inputTextZoom = findViewById<EditText>(R.id.inputTextZoomPercent)
@@ -90,6 +91,7 @@ class SettingsActivity : AppCompatActivity() {
         ftpPass.setText(prefs.getString("ftpPass", ""))
         ftpImportDir.setText(prefs.getString("ftp_import_dir", ""))
         ftpExportDir.setText(prefs.getString("ftp_export_dir", ""))
+        ftpProcessingDir.setText(prefs.getString("ftp_processing_dir", ""))
 
         // Значення масштабів, 100% за замовчуванням
         inputTextZoom.setText(prefs.getInt("textZoomPercent", 100).toString())
@@ -113,6 +115,7 @@ class SettingsActivity : AppCompatActivity() {
                 putString("ftpPass", ftpPass.text.toString())
                 putString("ftp_import_dir", ftpImportDir.text.toString())
                 putString("ftp_export_dir", ftpExportDir.text.toString())
+                putString("ftp_processing_dir", ftpProcessingDir.text.toString())
                 putInt("textZoomPercent", inputTextZoom.text.toString().toInt())
                 putInt("buttonZoomPercent", inputButtonZoom.text.toString().toInt())
                 apply()

--- a/app/src/main/java/ua/company/tzd/ui/orders/OrdersAdapter.kt
+++ b/app/src/main/java/ua/company/tzd/ui/orders/OrdersAdapter.kt
@@ -5,7 +5,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
-import java.io.File
+import android.graphics.Color
 
 /**
  * Адаптер для відображення списку файлів замовлень.
@@ -13,8 +13,8 @@ import java.io.File
  * @param onClick функція, яка буде викликана при натисканні на елемент
  */
 class OrdersAdapter(
-    private val orders: List<File>,
-    private val onClick: (File) -> Unit
+    private val orders: List<OrdersActivity.OrderInfo>,
+    private val onClick: (OrdersActivity.OrderInfo) -> Unit
 ) : RecyclerView.Adapter<OrdersAdapter.ViewHolder>() {
 
     /**
@@ -32,12 +32,17 @@ class OrdersAdapter(
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        // Заповнюємо текст назвою файлу
-        holder.text.text = orders[position].name
-        // Обробник натискання передає вибраний файл зовнішній функції
-        holder.itemView.setOnClickListener {
-            onClick(orders[position])
+        val info = orders[position]
+        // Відображаємо назву файлу
+        holder.text.text = info.file.name
+        // Колір фону в залежності від прапора блокування
+        if (info.isLocked) {
+            holder.itemView.setBackgroundColor(Color.YELLOW)
+        } else {
+            holder.itemView.setBackgroundColor(Color.TRANSPARENT)
         }
+        // Передаємо натискання разом з даними про файл
+        holder.itemView.setOnClickListener { onClick(info) }
     }
 
     override fun getItemCount(): Int = orders.size

--- a/app/src/main/res/layout/activity_drivers.xml
+++ b/app/src/main/res/layout/activity_drivers.xml
@@ -2,7 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:paddingTop="24dp">
 
     <!-- Область зі списком, яку можна оновити свайпом вниз -->
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,6 +5,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:padding="24dp"
+    android:paddingTop="24dp"
     android:gravity="center"
     android:background="#FAFAFA">
 

--- a/app/src/main/res/layout/activity_order_detail.xml
+++ b/app/src/main/res/layout/activity_order_detail.xml
@@ -2,7 +2,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:padding="8dp">
+    android:padding="8dp"
+    android:paddingTop="24dp">
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerOrderItems"

--- a/app/src/main/res/layout/activity_orders.xml
+++ b/app/src/main/res/layout/activity_orders.xml
@@ -2,7 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:paddingTop="24dp">
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerViewOrders"

--- a/app/src/main/res/layout/activity_product_list.xml
+++ b/app/src/main/res/layout/activity_product_list.xml
@@ -2,7 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:paddingTop="24dp">
 
     <ScrollView
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_scan.xml
+++ b/app/src/main/res/layout/activity_scan.xml
@@ -2,7 +2,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:padding="16dp">
+    android:padding="16dp"
+    android:paddingTop="24dp">
 
     <Button
         android:id="@+id/btnSimulateScan"

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -6,7 +6,8 @@
     <LinearLayout
         android:orientation="vertical"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:paddingTop="24dp">
 
         <!-- Заголовок секції налаштувань сканера -->
         <TextView
@@ -178,6 +179,13 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="Каталог експорту" />
+
+        <!-- Каталог для замовлень в обробці на сервері -->
+        <EditText
+            android:id="@+id/inputFtpProcessingDir"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Папка замовлень в обробці (processing)" />
 
         <!-- Заголовок секції "Масштаб" -->
         <TextView

--- a/app/src/main/res/layout/item_order_row.xml
+++ b/app/src/main/res/layout/item_order_row.xml
@@ -2,7 +2,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="horizontal"
-    android:padding="4dp">
+    android:padding="4dp"
+    android:paddingTop="24dp">
 
     <TextView
         android:id="@+id/txtCode"

--- a/app/src/main/res/layout/item_product.xml
+++ b/app/src/main/res/layout/item_product.xml
@@ -1,7 +1,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal">
+    android:orientation="horizontal"
+    android:paddingTop="24dp">
 
     <TextView
         android:id="@+id/codeTextView"


### PR DESCRIPTION
## Summary
- set paddingTop on root layouts
- add processing directory setting
- download processing files and mark locked
- block order and upload to FTP when scanning starts
- highlight locked orders in list

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c94f5f3bc8320b83800b567a91f71