### PR TITLE
Implement FTP and UI improvements

### DIFF
--- a/app/src/main/java/ua/company/tzd/ProductListActivity.kt
+++ b/app/src/main/java/ua/company/tzd/ProductListActivity.kt
@@ -12,7 +12,8 @@ import ua.company.tzd.utils.TextScaleHelper
 import org.apache.commons.net.ftp.FTPClient
 import org.xmlpull.v1.XmlPullParser
 import org.xmlpull.v1.XmlPullParserFactory
-import java.io.InputStream
+import java.io.File
+import java.io.FileOutputStream
 import java.net.InetAddress
 
 /**
@@ -84,13 +85,16 @@ class ProductListActivity : AppCompatActivity() {
                     ftpClient.enterLocalPassiveMode()
                     ftpClient.setFileType(FTPClient.BINARY_FILE_TYPE)
 
-                    // Витягаємо файл products.xml з вказаної у налаштуваннях папки
-                    val inputStream: InputStream = ftpClient.retrieveFileStream(importDir + "/products.xml")
+                    // Завантажуємо файл products.xml у локальну папку
+                    val localFile = File(filesDir, "products.xml")
+                    FileOutputStream(localFile).use { out ->
+                        ftpClient.retrieveFile("$importDir/products.xml", out)
+                    }
 
                     // Створюємо XML парсер для читання файлу
                     val factory = XmlPullParserFactory.newInstance()
                     val parser = factory.newPullParser()
-                    parser.setInput(inputStream, null)
+                    parser.setInput(localFile.inputStream(), null)
 
                     // Список пар "код" - "назва" для кожного товару
                     val products = mutableListOf<Pair<String, String>>()

--- a/app/src/main/java/ua/company/tzd/SettingsActivity.kt
+++ b/app/src/main/java/ua/company/tzd/SettingsActivity.kt
@@ -132,6 +132,7 @@ class SettingsActivity : AppCompatActivity() {
             val pass = ftpPass.text.toString().trim()
             val importDir = ftpImportDir.text.toString().trim()
             val exportDir = ftpExportDir.text.toString().trim()
+            val processingDir = ftpProcessingDir.text.toString().trim()
 
             // Запускаємо корутину в IO-потоці для роботи з мережею
             CoroutineScope(Dispatchers.IO).launch {
@@ -146,6 +147,7 @@ class SettingsActivity : AppCompatActivity() {
                         // Перевіряємо існування вказаних каталогів
                         val importExists = ftpClient.changeWorkingDirectory(importDir)
                         val exportExists = ftpClient.changeWorkingDirectory(exportDir)
+                        val processingExists = ftpClient.changeWorkingDirectory(processingDir)
 
                         // Повертаємося на головний потік для відображення результату
                         runOnUiThread {
@@ -163,6 +165,13 @@ class SettingsActivity : AppCompatActivity() {
                                         append("📂 Папка експорту існує\n")
                                     } else {
                                         append("❌ Папку експорту не знайдено\n")
+                                    }
+
+                                    append("📂 Папка обробки ")
+                                    if (processingExists) {
+                                        append("існує")
+                                    } else {
+                                        append("не знайдена")
                                     }
                                 }
 

--- a/app/src/main/java/ua/company/tzd/ui/orders/OrdersAdapter.kt
+++ b/app/src/main/java/ua/company/tzd/ui/orders/OrdersAdapter.kt
@@ -6,6 +6,7 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import android.graphics.Color
+import ua.company.tzd.ui.orders.ParsedOrderInfo
 
 /**
  * Адаптер для відображення списку файлів замовлень.
@@ -13,8 +14,10 @@ import android.graphics.Color
  * @param onClick функція, яка буде викликана при натисканні на елемент
  */
 class OrdersAdapter(
-    private val orders: List<OrdersActivity.OrderInfo>,
-    private val onClick: (OrdersActivity.OrderInfo) -> Unit
+    /** список інформації про замовлення */
+    private val orders: List<ParsedOrderInfo>,
+    /** функція, що викликається при натисканні на рядок */
+    private val onClick: (ParsedOrderInfo) -> Unit
 ) : RecyclerView.Adapter<OrdersAdapter.ViewHolder>() {
 
     /**
@@ -33,8 +36,9 @@ class OrdersAdapter(
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val info = orders[position]
-        // Відображаємо назву файлу
-        holder.text.text = info.file.name
+        // Формуємо рядок з номером, датою, клієнтом та сумарною вагою
+        holder.text.text = "№${info.number} | ${info.date} | ${info.client} | " +
+                "%.1f кг".format(info.totalWeight)
         // Колір фону в залежності від прапора блокування
         if (info.isLocked) {
             holder.itemView.setBackgroundColor(Color.YELLOW)

--- a/app/src/main/java/ua/company/tzd/ui/orders/ParsedOrderInfo.kt
+++ b/app/src/main/java/ua/company/tzd/ui/orders/ParsedOrderInfo.kt
@@ -1,0 +1,21 @@
+package ua.company.tzd.ui.orders
+
+import java.io.File
+
+/**
+ * Коротка інформація про замовлення, отримана під час парсингу XML.
+ * @property number номер замовлення
+ * @property date дата документа
+ * @property client назва клієнта
+ * @property totalWeight сумарна вага усіх позицій
+ * @property isLocked чи містить файл тег <блокування>
+ * @property file сам файл замовлення
+ */
+data class ParsedOrderInfo(
+    val number: String,
+    val date: String,
+    val client: String,
+    val totalWeight: Double,
+    val isLocked: Boolean = false,
+    val file: File
+)

--- a/app/src/main/res/layout/activity_order_detail.xml
+++ b/app/src/main/res/layout/activity_order_detail.xml
@@ -5,15 +5,43 @@
     android:padding="8dp"
     android:paddingTop="24dp">
 
+    <TextView
+        android:id="@+id/scanStatus"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Активне сканування"
+        android:textStyle="bold"
+        android:gravity="center"
+        android:padding="8dp"
+        android:background="#FFEB3B"
+        android:visibility="gone"/>
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerOrderItems"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1"/>
+        android:layout_weight="1"
+        android:paddingTop="16dp"/>
 
-    <Button
-        android:id="@+id/btnStartScan"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Сканувати" />
+        android:orientation="horizontal"
+        android:paddingTop="8dp"
+        android:weightSum="2">
+
+        <Button
+            android:id="@+id/btnBack"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:text="Назад"/>
+
+        <Button
+            android:id="@+id/btnStartScan"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:text="Сканувати"/>
+    </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1,7 +1,8 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:padding="16dp">
+    android:padding="16dp"
+    android:paddingTop="24dp">
 
     <LinearLayout
         android:orientation="vertical"


### PR DESCRIPTION
## Summary
- improve drivers screen FTP sync and toast status
- parse order files for display info
- show detailed order rows
- store products.xml locally and use names while parsing orders
- add scan indicator and back button to order detail
- verify processing directory in settings
- adjust layout padding

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c9ffcc0f48320bee7cd2762e5f4da