### PR TITLE
add order sync and status utilities

### DIFF
--- a/app/src/main/java/ua/company/tzd/SettingsActivity.kt
+++ b/app/src/main/java/ua/company/tzd/SettingsActivity.kt
@@ -50,6 +50,10 @@ class SettingsActivity : AppCompatActivity() {
         val ftpImportDir = findViewById<EditText>(R.id.inputFtpImportDir)
         val ftpExportDir = findViewById<EditText>(R.id.inputFtpExportDir)
         val ftpProcessingDir = findViewById<EditText>(R.id.inputFtpProcessingDir)
+        // Інтервал між автоматичними збереженнями замовлення
+        val autosaveInterval = findViewById<EditText>(R.id.inputAutosaveInterval)
+        // Назва пристрою, що буде записуватися у тег <блокування>
+        val deviceName = findViewById<EditText>(R.id.inputDeviceName)
 
         // Поля масштабування тексту та кнопок
         val inputTextZoom = findViewById<EditText>(R.id.inputTextZoomPercent)
@@ -92,6 +96,8 @@ class SettingsActivity : AppCompatActivity() {
         ftpImportDir.setText(prefs.getString("ftp_import_dir", ""))
         ftpExportDir.setText(prefs.getString("ftp_export_dir", ""))
         ftpProcessingDir.setText(prefs.getString("ftp_processing_dir", ""))
+        autosaveInterval.setText(prefs.getInt("autosaveIntervalMinutes", 2).toString())
+        deviceName.setText(prefs.getString("deviceName", ""))
 
         // Значення масштабів, 100% за замовчуванням
         inputTextZoom.setText(prefs.getInt("textZoomPercent", 100).toString())
@@ -116,6 +122,8 @@ class SettingsActivity : AppCompatActivity() {
                 putString("ftp_import_dir", ftpImportDir.text.toString())
                 putString("ftp_export_dir", ftpExportDir.text.toString())
                 putString("ftp_processing_dir", ftpProcessingDir.text.toString())
+                putInt("autosaveIntervalMinutes", autosaveInterval.text.toString().toInt())
+                putString("deviceName", deviceName.text.toString())
                 putInt("textZoomPercent", inputTextZoom.text.toString().toInt())
                 putInt("buttonZoomPercent", inputButtonZoom.text.toString().toInt())
                 apply()

--- a/app/src/main/java/ua/company/tzd/ui/orders/Order.kt
+++ b/app/src/main/java/ua/company/tzd/ui/orders/Order.kt
@@ -1,0 +1,103 @@
+package ua.company.tzd.ui.orders
+
+import org.xmlpull.v1.XmlPullParser
+import org.xmlpull.v1.XmlPullParserFactory
+import java.io.InputStream
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+/**
+ * Представляє одне замовлення, зчитане з FTP-сервера.
+ * @property number номер документа
+ * @property date дата створення
+ * @property clientName назва клієнта
+ * @property driver ім'я водія, якому належить замовлення
+ * @property items список позицій замовлення
+ * @property source з якої папки було отримано документ
+ * @property lockedBy назва пристрою, що заблокувало замовлення
+ * @property lockTime час встановлення блокування
+ */
+data class Order(
+    val number: String,
+    val date: LocalDate,
+    val clientName: String,
+    val driver: String,
+    val items: MutableList<OrderItem> = mutableListOf(),
+    val source: OrderSource = OrderSource.IMPORT,
+    var lockedBy: String? = null,
+    var lockTime: LocalDateTime? = null
+) {
+    companion object {
+        /**
+         * Зчитує XML та формує об'єкт [Order].
+         * @param stream вхідний потік XML-файлу
+         * @param source директорія, з якої був завантажений файл
+         */
+        fun fromXml(stream: InputStream, source: OrderSource): Order {
+            var number = ""
+            var date: LocalDate = LocalDate.now()
+            var client = ""
+            var driver = ""
+            val items = mutableListOf<OrderItem>()
+            var lockedBy: String? = null
+            var lockTime: LocalDateTime? = null
+
+            // Готуємо парсер XML
+            val parser = XmlPullParserFactory.newInstance().newPullParser()
+            parser.setInput(stream, null)
+
+            var event = parser.eventType
+            var currentItem: OrderItem? = null
+
+            while (event != XmlPullParser.END_DOCUMENT) {
+                when (event) {
+                    XmlPullParser.START_TAG -> when (parser.name) {
+                        "номер" -> number = parser.nextText()
+                        "дата" -> date = LocalDate.parse(parser.nextText())
+                        "клієнт" -> client = parser.nextText()
+                        "водій" -> driver = parser.nextText()
+                        "позиція" -> currentItem = OrderItem()
+                        "код" -> currentItem?.code = parser.nextText()
+                        "вага" -> currentItem?.weight = parser.nextText().toDoubleOrNull() ?: 0.0
+                        "факт_вага" -> currentItem?.factWeight = parser.nextText().toDoubleOrNull()
+                        "факт_кількість" -> currentItem?.factCount = parser.nextText().toDoubleOrNull()
+                        "блокування" -> {
+                            val parts = parser.nextText().split(",")
+                            if (parts.size == 2) {
+                                lockedBy = parts[0]
+                                lockTime = try {
+                                    LocalDateTime.parse(parts[1])
+                                } catch (e: Exception) {
+                                    null
+                                }
+                            }
+                        }
+                    }
+                    XmlPullParser.END_TAG -> if (parser.name == "позиція" && currentItem != null) {
+                        items.add(currentItem)
+                        currentItem = null
+                    }
+                }
+                event = parser.next()
+            }
+
+            return Order(number, date, client, driver, items, source, lockedBy, lockTime)
+        }
+    }
+}
+
+/**
+ * Окрема позиція замовлення.
+ */
+data class OrderItem(
+    var code: String = "",
+    var weight: Double = 0.0,
+    var factWeight: Double? = null,
+    var factCount: Double? = null
+)
+
+/**
+ * Звідки було отримано файл замовлення.
+ */
+enum class OrderSource { IMPORT, PROCESSING }
+

--- a/app/src/main/java/ua/company/tzd/ui/orders/OrderListAdapter.kt
+++ b/app/src/main/java/ua/company/tzd/ui/orders/OrderListAdapter.kt
@@ -1,0 +1,53 @@
+package ua.company.tzd.ui.orders
+
+import android.graphics.Color
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import java.time.LocalDateTime
+
+/**
+ * Адаптер для відображення списку замовлень із підсвічуванням стану.
+ * @param orders список замовлень
+ * @param currentDevice назва поточного пристрою
+ * @param autosaveInterval інтервал автозбереження у хвилинах
+ * @param onClick дія при натисканні на рядок
+ */
+class OrderListAdapter(
+    private val orders: List<Order>,
+    private val currentDevice: String,
+    private val autosaveInterval: Long,
+    private val onClick: (Order) -> Unit
+) : RecyclerView.Adapter<OrderListAdapter.ViewHolder>() {
+
+    class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val text: TextView = view.findViewById(android.R.id.text1)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(android.R.layout.simple_list_item_1, parent, false)
+        return ViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        val order = orders[position]
+        holder.text.text = "№${order.number} | ${order.clientName}"
+
+        val status = getOrderStatus(order, currentDevice, LocalDateTime.now(), autosaveInterval)
+        val color = when {
+            order.source == OrderSource.IMPORT && status == OrderStatus.NEW -> Color.GREEN
+            order.source == OrderSource.PROCESSING && status == OrderStatus.LOCKED_BY_ME -> Color.YELLOW
+            order.source == OrderSource.PROCESSING && status == OrderStatus.LOCKED_BY_OTHER -> Color.RED
+            order.source == OrderSource.PROCESSING && status == OrderStatus.EXPIRED_LOCK -> 0xFFAEEA00.toInt()
+            else -> Color.TRANSPARENT
+        }
+        holder.itemView.setBackgroundColor(color)
+        holder.itemView.setOnClickListener { onClick(order) }
+    }
+
+    override fun getItemCount(): Int = orders.size
+}
+

--- a/app/src/main/java/ua/company/tzd/ui/orders/OrderScanActivity.kt
+++ b/app/src/main/java/ua/company/tzd/ui/orders/OrderScanActivity.kt
@@ -1,0 +1,80 @@
+package ua.company.tzd.ui.orders
+
+import android.os.Bundle
+import android.widget.Button
+import androidx.appcompat.app.AppCompatActivity
+import kotlinx.coroutines.*
+import ua.company.tzd.utils.FTPManager
+import java.time.LocalDateTime
+
+/**
+ * Екран сканування окремого замовлення.
+ * Під час роботи ми переміщуємо файл у папку processing та
+ * періодично зберігаємо його на сервері.
+ */
+class OrderScanActivity : AppCompatActivity() {
+    private var order: Order? = null
+    private var ftp: FTPManager? = null
+    private var autosaveJob: Job? = null
+    private var deviceName: String = ""
+    private var autosaveInterval: Long = 2
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        // У реальному застосунку тут має бути розмітка зі списком позицій та кнопками
+        val button = Button(this).apply { text = "Сканувати" }
+        setContentView(button)
+
+        deviceName = intent.getStringExtra("deviceName") ?: ""
+        autosaveInterval = intent.getLongExtra("autosaveInterval", 2)
+
+        // При натисканні "Сканувати" оновлюємо lock та переміщуємо файл
+        button.setOnClickListener {
+            order?.let { ord ->
+                ord.lockedBy = deviceName
+                ord.lockTime = LocalDateTime.now()
+                // Зберігаємо файл у папку processing
+                saveOrder(true)
+            }
+        }
+    }
+
+    /**
+     * Запускає автозбереження кожні [autosaveInterval] хвилин.
+     */
+    private fun startAutosave() {
+        autosaveJob = CoroutineScope(Dispatchers.IO).launch {
+            while (isActive) {
+                delay(autosaveInterval * 60 * 1000)
+                saveOrder(true)
+            }
+        }
+    }
+
+    /**
+     * Записуємо поточне замовлення на FTP-сервер.
+     * Якщо [updateLock] = true, оновлюємо час блокування.
+     */
+    private fun saveOrder(updateLock: Boolean) {
+        val currentOrder = order ?: return
+        if (updateLock) {
+            currentOrder.lockTime = LocalDateTime.now()
+        }
+        // У реальному застосунку тут потрібно сформувати XML.
+        // Для простоти ми записуємо порожній файл з номером замовлення.
+        val content = "<замовлення номер=\"${currentOrder.number}\"/>".toByteArray()
+        ftp?.uploadFile("/processing/", "${currentOrder.number}.xml", content)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        startAutosave()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        autosaveJob?.cancel()
+        saveOrder(false)
+    }
+}
+

--- a/app/src/main/java/ua/company/tzd/ui/orders/OrderStatusUtils.kt
+++ b/app/src/main/java/ua/company/tzd/ui/orders/OrderStatusUtils.kt
@@ -1,0 +1,37 @@
+package ua.company.tzd.ui.orders
+
+import java.time.Duration
+import java.time.LocalDateTime
+
+/**
+ * Можливі стани замовлення для відображення в інтерфейсі.
+ */
+enum class OrderStatus { NEW, LOCKED_BY_ME, LOCKED_BY_OTHER, EXPIRED_LOCK }
+
+/**
+ * Визначаємо статус замовлення на основі блокування та часу.
+ * @param order замовлення, що перевіряємо
+ * @param currentDevice ім'я поточного пристрою
+ * @param now поточний момент часу
+ * @param autosaveInterval інтервал автозбереження у хвилинах
+ */
+fun getOrderStatus(
+    order: Order,
+    currentDevice: String,
+    now: LocalDateTime,
+    autosaveInterval: Long
+): OrderStatus {
+    val lockedBy = order.lockedBy
+    val lockTime = order.lockTime
+    val isActive = if (lockTime != null) {
+        Duration.between(lockTime, now).toMinutes() < autosaveInterval
+    } else false
+
+    return when {
+        lockedBy == null -> OrderStatus.NEW
+        lockedBy == currentDevice && isActive -> OrderStatus.LOCKED_BY_ME
+        lockedBy != currentDevice && isActive -> OrderStatus.LOCKED_BY_OTHER
+        else -> OrderStatus.EXPIRED_LOCK
+    }
+}
+

--- a/app/src/main/java/ua/company/tzd/ui/orders/OrderSyncManager.kt
+++ b/app/src/main/java/ua/company/tzd/ui/orders/OrderSyncManager.kt
@@ -1,0 +1,37 @@
+package ua.company.tzd.ui.orders
+
+import ua.company.tzd.utils.FTPManager
+
+/**
+ * Відповідає за синхронізацію замовлень з FTP-сервера.
+ * Зчитує XML-файли з папок /import та /processing та об'єднує їх у єдиний список.
+ */
+class OrderSyncManager(
+    private val ftp: FTPManager,
+    private val importDir: String,
+    private val processingDir: String
+) {
+    /**
+     * Виконує синхронізацію та повертає список замовлень.
+     * Якщо замовлення з однаковим номером існує в обох папках,
+     * перевага надається файлу з папки processing.
+     */
+    fun syncOrders(): List<Order> {
+        val map = mutableMapOf<String, Order>()
+
+        // Зчитуємо замовлення з папки import
+        ftp.readXmlFiles(importDir).forEach { (_, stream) ->
+            val order = Order.fromXml(stream, OrderSource.IMPORT)
+            map[order.number] = order
+        }
+
+        // Зчитуємо замовлення з папки processing, перезаписуючи попередні
+        ftp.readXmlFiles(processingDir).forEach { (_, stream) ->
+            val order = Order.fromXml(stream, OrderSource.PROCESSING)
+            map[order.number] = order
+        }
+
+        return map.values.toList()
+    }
+}
+

--- a/app/src/main/java/ua/company/tzd/utils/FTPManager.kt
+++ b/app/src/main/java/ua/company/tzd/utils/FTPManager.kt
@@ -1,0 +1,70 @@
+package ua.company.tzd.utils
+
+import org.apache.commons.net.ftp.FTPClient
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+
+/**
+ * Допоміжний клас для роботи з FTP-сервером.
+ * Дозволяє читати та записувати XML-файли з каталогів /import та /processing.
+ */
+class FTPManager(
+    private val host: String,
+    private val port: Int,
+    private val user: String,
+    private val pass: String
+) {
+    /**
+     * Створюємо підключення до сервера і повертаємо готовий клієнт.
+     */
+    private fun connect(): FTPClient {
+        val client = FTPClient()
+        client.connect(host, port)
+        client.login(user, pass)
+        client.enterLocalPassiveMode()
+        return client
+    }
+
+    /**
+     * Зчитує всі XML-файли з вказаного каталогу.
+     * Повертає карту: ім'я файлу -> вміст у вигляді потоку.
+     */
+    fun readXmlFiles(directory: String): Map<String, InputStream> {
+        val result = mutableMapOf<String, InputStream>()
+        val client = connect()
+        try {
+            client.changeWorkingDirectory(directory)
+            client.listFiles().forEach { file ->
+                if (file.name.endsWith(".xml")) {
+                    val stream = client.retrieveFileStream(file.name)
+                    if (stream != null) {
+                        // Копіюємо вміст, щоб можна було закрити FTP-з'єднання
+                        val bytes = stream.readBytes()
+                        stream.close()
+                        result[file.name] = ByteArrayInputStream(bytes)
+                        client.completePendingCommand()
+                    }
+                }
+            }
+        } finally {
+            client.logout()
+            client.disconnect()
+        }
+        return result
+    }
+
+    /**
+     * Завантажує файл у заданий каталог.
+     */
+    fun uploadFile(directory: String, name: String, content: ByteArray) {
+        val client = connect()
+        try {
+            client.changeWorkingDirectory(directory)
+            client.storeFile(name, ByteArrayInputStream(content))
+        } finally {
+            client.logout()
+            client.disconnect()
+        }
+    }
+}
+

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -187,6 +187,26 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="Папка замовлень в обробці (processing)" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Інтервал автозбереження (хв):" />
+        <EditText
+            android:id="@+id/inputAutosaveInterval"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="number"
+            android:hint="2" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Назва пристрою:" />
+        <EditText
+            android:id="@+id/inputDeviceName"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Пристрій 1" />
+
 
         <!-- Заголовок секції "Масштаб" -->
         <TextView


### PR DESCRIPTION
## Summary
- add `Order` model with lock parsing
- implement FTP helper and sync manager
- add UI helpers: order list adapter, scan activity
- extend settings with device and autosave options

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e1d10dda08320a4913da7b21d7924