### PR TITLE
fix: separate display order item model

### DIFF
--- a/app/src/main/java/ua/company/tzd/ui/orders/OrderDetailActivity.kt
+++ b/app/src/main/java/ua/company/tzd/ui/orders/OrderDetailActivity.kt
@@ -24,8 +24,11 @@ import android.view.View
  */
 class OrderDetailActivity : AppCompatActivity() {
 
-    /** Список позицій, зчитаних з файлу замовлення */
-    private val items = mutableListOf<OrderItem>()
+    /**
+     * Список позицій для показу у RecyclerView.
+     * Використовуємо окремий клас [DisplayOrderItem], щоб не конфліктувати з основною моделлю [OrderItem].
+     */
+    private val items = mutableListOf<DisplayOrderItem>()
 
     /** Мапа код -> назва товару, зчитана з файлу products.xml */
     private val productNames = mutableMapOf<String, String>()
@@ -40,6 +43,7 @@ class OrderDetailActivity : AppCompatActivity() {
         // Налаштовуємо список позицій
         val recycler = findViewById<RecyclerView>(R.id.recyclerOrderItems)
         recycler.layoutManager = LinearLayoutManager(this)
+        // Створюємо адаптер і передаємо йому список позицій для відображення
         adapter = OrderItemAdapter(items)
         recycler.adapter = adapter
 
@@ -143,7 +147,8 @@ class OrderDetailActivity : AppCompatActivity() {
                     XmlPullParser.END_TAG -> if (parser.name == "позиція") {
                         // Кінець позиції – додаємо її у список
                         val finalName = productNames[code] ?: if (name.isNotEmpty()) name else "???"
-                        items.add(OrderItem(code, finalName, weight))
+                        // Додаємо у список новий елемент для відображення в таблиці
+                        items.add(DisplayOrderItem(code, finalName, weight))
                     }
                 }
                 event = parser.next()

--- a/app/src/main/java/ua/company/tzd/ui/orders/OrderItemAdapter.kt
+++ b/app/src/main/java/ua/company/tzd/ui/orders/OrderItemAdapter.kt
@@ -8,14 +8,15 @@ import androidx.recyclerview.widget.RecyclerView
 import ua.company.tzd.R
 
 /**
- * Дані однієї позиції замовлення.
+ * Дані однієї позиції для відображення на екрані замовлення.
+ * Використовується тільки у списку та не впливає на основну модель даних.
  * @param code код товару
  * @param name назва товару
  * @param expectedWeight очікувана вага, яку має бути відвантажено
  * @param actualWeight фактична вага вже відсканованого товару
  * @param actualPacks фактична кількість упаковок
  */
-data class OrderItem(
+data class DisplayOrderItem(
     val code: String,
     val name: String,
     val expectedWeight: Double,
@@ -27,7 +28,7 @@ data class OrderItem(
  * Адаптер для таблиці позицій замовлення.
  * Показує код, назву, очікувану та фактичну вагу і кількість упаковок.
  */
-class OrderItemAdapter(private val items: List<OrderItem>) :
+class OrderItemAdapter(private val items: List<DisplayOrderItem>) :
     RecyclerView.Adapter<OrderItemAdapter.ViewHolder>() {
 
     /** ViewHolder зберігає посилання на текстові поля одного рядка */


### PR DESCRIPTION
## Summary
- rename RecyclerView item model to `DisplayOrderItem`
- update order detail screen to use `DisplayOrderItem`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e2aeeea888320b6b6912a1107470b