### PR TITLE
Fix OrderItem redeclaration in UI

### DIFF
--- a/app/src/main/java/ua/company/tzd/ui/orders/OrderDetailActivity.kt
+++ b/app/src/main/java/ua/company/tzd/ui/orders/OrderDetailActivity.kt
@@ -17,6 +17,7 @@ import org.xmlpull.v1.XmlPullParserFactory
 import ua.company.tzd.R
 import java.io.File
 import android.view.View
+import ua.company.tzd.ui.orders.DisplayOrderItem
 
 /**
  * Екран деталізації замовлення.
@@ -24,8 +25,12 @@ import android.view.View
  */
 class OrderDetailActivity : AppCompatActivity() {
 
-    /** Список позицій, зчитаних з файлу замовлення */
-    private val items = mutableListOf<OrderItem>()
+    /**
+     * Список позицій для відображення.
+     * Використовуємо [DisplayOrderItem], щоб показати дані на екрані
+     * та уникнути конфлікту з логічним класом [OrderItem] із `Order.kt`.
+     */
+    private val items = mutableListOf<DisplayOrderItem>()
 
     /** Мапа код -> назва товару, зчитана з файлу products.xml */
     private val productNames = mutableMapOf<String, String>()
@@ -141,9 +146,9 @@ class OrderDetailActivity : AppCompatActivity() {
                         "вага" -> weight = parser.nextText().toDoubleOrNull() ?: 0.0
                     }
                     XmlPullParser.END_TAG -> if (parser.name == "позиція") {
-                        // Кінець позиції – додаємо її у список
+                        // Кінець позиції – формуємо об'єкт для відображення і додаємо у список
                         val finalName = productNames[code] ?: if (name.isNotEmpty()) name else "???"
-                        items.add(OrderItem(code, finalName, weight))
+                        items.add(DisplayOrderItem(code, finalName, weight))
                     }
                 }
                 event = parser.next()

--- a/app/src/main/java/ua/company/tzd/ui/orders/OrderItemAdapter.kt
+++ b/app/src/main/java/ua/company/tzd/ui/orders/OrderItemAdapter.kt
@@ -8,14 +8,16 @@ import androidx.recyclerview.widget.RecyclerView
 import ua.company.tzd.R
 
 /**
- * Дані однієї позиції замовлення.
- * @param code код товару
- * @param name назва товару
- * @param expectedWeight очікувана вага, яку має бути відвантажено
- * @param actualWeight фактична вага вже відсканованого товару
- * @param actualPacks фактична кількість упаковок
+ * Окремий рядок для відображення позиції замовлення у списку.
+ * Цей клас призначений виключно для показу інформації на екрані,
+ * щоб не плутати його з логічною моделлю [OrderItem] з файлу `Order.kt`.
+ * @param code код товару, зручний для швидкого пошуку по списку
+ * @param name читабельна назва товару, яку бачить користувач
+ * @param expectedWeight вага, яку система очікує відвантажити
+ * @param actualWeight поточна фактична вага вже відсканованого товару
+ * @param actualPacks фактична кількість упаковок, що вже відскановані
  */
-data class OrderItem(
+data class DisplayOrderItem(
     val code: String,
     val name: String,
     val expectedWeight: Double,
@@ -25,9 +27,9 @@ data class OrderItem(
 
 /**
  * Адаптер для таблиці позицій замовлення.
- * Показує код, назву, очікувану та фактичну вагу і кількість упаковок.
+ * Використовує [DisplayOrderItem], щоб відобразити код, назву та вагу товару.
  */
-class OrderItemAdapter(private val items: List<OrderItem>) :
+class OrderItemAdapter(private val items: List<DisplayOrderItem>) :
     RecyclerView.Adapter<OrderItemAdapter.ViewHolder>() {
 
     /** ViewHolder зберігає посилання на текстові поля одного рядка */


### PR DESCRIPTION
## Summary
- rename UI OrderItem data class to DisplayOrderItem
- update adapter and activity to use DisplayOrderItem and add comments

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e46ab6e388320b2867690d78b36a2